### PR TITLE
review: decisions belong under the section that motivates them

### DIFF
--- a/docs/templates/review.md
+++ b/docs/templates/review.md
@@ -20,11 +20,13 @@ easel open --template review --data plan.json --title "Retry budget"
       "badges": [                    // optional
         "plain label",
         { "label": "string", "tone": "success|warning|error|info" }
-      ]
+      ],
+      "decisions": [ ... ],          // optional, same shape as top-level; renders inside the section
+      "votes": [ ... ]               // optional, same shape as top-level; renders inside the section
     }
   ],
 
-  "decisions": [                     // optional
+  "decisions": [                     // optional — board-wide only; see placement rule below
     {
       "id": "string",                // required, unique across the board
       "question": "string",          // required
@@ -49,7 +51,9 @@ easel open --template review --data plan.json --title "Retry budget"
 }
 ```
 
-At least one of `sections`, `decisions`, or `votes` must be present. `id` values must be unique across decisions *and* votes on the board — a collision throws, because two widgets sharing an id would record to the same key.
+At least one of `sections`, `decisions`, or `votes` must be present. `id` values must be unique across decisions *and* votes on the board — inline and top-level alike — a collision throws, because two widgets sharing an id would record to the same key.
+
+**Placement rule: put each decision inside the section that motivates it** (`sections[].decisions`), so the reader answers with the relevant context directly above — never make them scroll back up from a pile at the bottom. Top-level `decisions`/`votes` render in a trailing "Decisions"/"Votes" section; reserve those for calls that genuinely span the whole board (final approve, overall verdict). A board whose every decision sits at the bottom is almost always mis-authored.
 
 ## Markdown supported in prose fields
 

--- a/templates/review.js
+++ b/templates/review.js
@@ -18,6 +18,33 @@ export function render(data) {
 
   const uniqueId = makeIdGuard('review')
 
+  const renderDecision = (d, path) => {
+    requireObject(d, path)
+    return [
+      '<div class="sd-card">',
+      widget({
+        type: 'decision',
+        id: uniqueId(d.id, `${path}.id`),
+        prompt: requireString(d.question, `${path}.question`),
+        help: d.context,
+        options: requireArray(d.options, `${path}.options`),
+      }),
+      d.detail ? `<div class="sd-muted">${markdown(d.detail)}</div>` : '',
+      '</div>',
+    ].filter(Boolean).join('\n')
+  }
+
+  const renderVote = (v, path) => {
+    requireObject(v, path)
+    return widget({
+      type: v.type === 'approve' ? 'approve' : 'vote',
+      id: uniqueId(v.id, `${path}.id`),
+      prompt: requireString(v.question, `${path}.question`),
+      help: v.context,
+      options: requireArray(v.options ?? ['yes', 'no'], `${path}.options`),
+    })
+  }
+
   const head = [
     `<h1>${esc(data.title)}</h1>`,
     data.summary ? `<div class="sd-muted">${markdown(data.summary)}</div>` : '',
@@ -33,11 +60,17 @@ export function render(data) {
         const tone = typeof b === 'string' ? null : b.tone
         return badge(label, tone, `review.sections[${i}].badges tone`)
       }).join('')
+    const inlineDecisions = requireArray(s.decisions ?? [], `review.sections[${i}].decisions`)
+      .map((d, j) => renderDecision(d, `review.sections[${i}].decisions[${j}]`)).join('\n')
+    const inlineVotes = requireArray(s.votes ?? [], `review.sections[${i}].votes`)
+      .map((v, j) => renderVote(v, `review.sections[${i}].votes[${j}]`)).join('\n')
     return [
       '<section class="sd-section">',
       `<h2>${esc(s.heading)}</h2>`,
       badges ? `<div class="sd-row">${badges}</div>` : '',
       body,
+      inlineDecisions,
+      inlineVotes,
       '</section>',
     ].filter(Boolean).join('\n')
   }).join('\n')
@@ -46,22 +79,7 @@ export function render(data) {
     ? [
         '<section class="sd-section">',
         '<h2>Decisions</h2>',
-        decisions.map((d, i) => {
-          requireObject(d, `review.decisions[${i}]`)
-          const id = uniqueId(d.id, `review.decisions[${i}].id`)
-          return [
-            '<div class="sd-card">',
-            widget({
-              type: 'decision',
-              id,
-              prompt: requireString(d.question, `review.decisions[${i}].question`),
-              help: d.context,
-              options: requireArray(d.options, `review.decisions[${i}].options`),
-            }),
-            d.detail ? `<div class="sd-muted">${markdown(d.detail)}</div>` : '',
-            '</div>',
-          ].filter(Boolean).join('\n')
-        }).join('\n'),
+        decisions.map((d, i) => renderDecision(d, `review.decisions[${i}]`)).join('\n'),
         '</section>',
       ].join('\n')
     : ''
@@ -70,16 +88,7 @@ export function render(data) {
     ? [
         '<section class="sd-section">',
         '<h2>Votes</h2>',
-        votes.map((v, i) => {
-          requireObject(v, `review.votes[${i}]`)
-          return widget({
-            type: v.type === 'approve' ? 'approve' : 'vote',
-            id: uniqueId(v.id, `review.votes[${i}].id`),
-            prompt: requireString(v.question, `review.votes[${i}].question`),
-            help: v.context,
-            options: requireArray(v.options ?? ['yes', 'no'], `review.votes[${i}].options`),
-          })
-        }).join('\n'),
+        votes.map((v, i) => renderVote(v, `review.votes[${i}]`)).join('\n'),
         '</section>',
       ].join('\n')
     : ''

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -279,6 +279,29 @@ describe('review', () => {
     assert.match(html, /data-widget="approve"/)
   })
 
+  test('renders section-inline decisions and votes inside the section', () => {
+    const html = review.render({
+      title: 't',
+      sections: [{
+        heading: 'Retry budget',
+        body: 'context',
+        decisions: [{ id: 'inline-d', question: 'q', options: ['a', 'b'] }],
+        votes: [{ id: 'inline-v', question: 'ok?', type: 'approve' }],
+      }],
+    })
+    const section = html.slice(html.indexOf('<section'), html.indexOf('</section>'))
+    assert.match(section, /data-widget-id="inline-d"/)
+    assert.match(section, /data-widget-id="inline-v"/)
+  })
+
+  test('rejects duplicate widget ids between inline and top-level', () => {
+    assert.throws(() => review.render({
+      title: 't',
+      sections: [{ heading: 'h', decisions: [{ id: 'dup', question: 'q', options: ['a'] }] }],
+      decisions: [{ id: 'dup', question: 'q', options: ['a'] }],
+    }), TemplateError)
+  })
+
   test('rejects duplicate widget ids across decisions and votes', () => {
     assert.throws(() => review.render({
       title: 't',


### PR DESCRIPTION
The `review` template structurally forced every decision into one trailing "Decisions" section, so boards routinely ended with a pile of questions the reader had to scroll back up to answer.

- `sections[]` now takes optional `decisions` / `votes` arrays, rendered inline after the section body.
- Top-level arrays still render at the bottom — reserved for genuinely board-wide calls (final approve, overall verdict).
- The id-uniqueness guard spans inline + top-level, so a collision still throws.
- `docs/templates/review.md` carries the schema and an explicit placement rule; that's the doc the skill points agents at before authoring review data, so SKILL.md is unchanged.

Tests: two new cases (inline widgets render inside their section; cross-scope duplicate id throws). `node --test test/templates.test.js` → 86 pass.

Verified live on an existing board: after `easel update` + republish, each decision widget now sits under its own section heading (phase0-guard → §4, prod-cleanup → §5, linear-ticket → §7), with only the board-wide approve vote trailing.