### PR TITLE
deps: clear 9 dependabot alerts via transitive overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,13 +80,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@chevrotain/gast": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
@@ -104,13 +97,6 @@
       "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/gast/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@chevrotain/regexp-to-ast": {
       "version": "11.0.3",
@@ -2308,13 +2294,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/chevrotain/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -3028,9 +3007,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3497,9 +3476,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -61,5 +61,10 @@
     "esbuild": "0.28.1",
     "react": "19.2.8",
     "react-dom": "19.2.8"
+  },
+  "overrides": {
+    "mermaid": "11.16.1",
+    "dompurify": "3.4.13",
+    "lodash-es": "4.18.1"
   }
 }


### PR DESCRIPTION
Clears all 9 open dependabot alerts (1 high, 7 moderate, 1 low) on the default branch. All three flagged packages are transitive, so this is four lines of `overrides` — no direct dependency version changes.

| Package | Alerts | Change |
|---|---|---|
| mermaid | 5 (prototype pollution, CSS injection, 2× DoS) | 11.16.0 → 11.16.1 |
| dompurify | 1 (IN_PLACE hook detached subtree) | 3.4.12 → 3.4.13 |
| lodash-es | 3 (`_.template` code injection, prototype pollution) | pinned 4.17.21 copies inside chevrotain → 4.18.1 |

`npm audit` goes 9 → 3. The 3 that remain are Excalidraw-internal (`nanoid` predictable results, reachable only through the whiteboard bundle) and their only offered fix is a semver-major downgrade of `@excalidraw/excalidraw` to 0.17.6 — forcing nanoid to 5.x crosses two ESM-only major boundaries in the esbuild bundle, which is a worse trade than the finding.

## Verification

- Full suite: **593/593 pass** (includes `mermaid.test.js`, `mermaid-contrast.test.js`, `diagram-label-fit.test.js`).
- Excalidraw bundle rebuilt clean against the new tree (`render/build-excalidraw.mjs`).
- End-to-end through the live daemon: published a two-diagram board (flowchart + sequence) after `easel update`. The baked round contains 8 `<svg>` elements, **0** unrendered `class="mermaid"` blocks, 4 whiteboard-openable diagram wrappers, and no syntax-error markers — so the mermaid bump did not regress the publish-time render path.

https://claude.ai/code/session_01YRodF27EjuP7CdVTbzfAMv