### PR TITLE
Auto-update, opt-in by design

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Open the URL, annotate, hit Send — the blocked `easel await` returns your feed
 
 `http://127.0.0.1:4400/` lists every board and marks which ones have an agent waiting on you.
 
+Updates never install themselves. `easel update` is the manual upgrade; `easel autoupdate on` opts into a daily one — off by default because an auto-updater is standing permission to run whatever the remote ships next, and [docs/usage.md § Auto-update](docs/usage.md#auto-update) explains the shipped one and why writing your own is worth the exercise.
+
 To back out, `install/install.sh --uninstall` removes the agent, the plist, and the `easel` entry point. It leaves `~/.easel/` — your boards and database — deliberately intact; `rm -rf ~/.easel` is the separate, deliberate step that erases them.
 
 ## The commands
@@ -50,6 +52,7 @@ To back out, `install/install.sh --uninstall` removes the agent, the plist, and 
 | `easel end <key>` | close a board — reads keep working, writes 409 |
 | `easel purge [--older-than 30d]` | delete untouched boards and shrink the DB |
 | `easel update` | pull, rebuild, restart, health-check the installed checkout |
+| `easel autoupdate on\|off\|status` | opt-in daily unattended update — off by default, deliberately |
 
 ## What you get on the page
 

--- a/cli/easel.js
+++ b/cli/easel.js
@@ -20,7 +20,8 @@ const USAGE = `usage:
   easel end <key> [--reopen] [--json]
   easel gc [--older-than 7d] [--json]
   easel purge [--older-than 30d] [--json]
-  easel update`
+  easel update
+  easel autoupdate on [--at HH:MM] | off | status`
 
 // Throws {connection: true} on transport failure, {http: true} on a non-2xx.
 async function request(method, path, body, { timeoutMs } = {}) {
@@ -262,6 +263,23 @@ const commands = {
   async update() {
     const script = resolve(dirname(fileURLToPath(import.meta.url)), '../install/update.sh')
     const { status, error } = spawnSync('bash', [script], { stdio: 'inherit' })
+    if (error) fail(error.message)
+    process.exit(status ?? 1)
+  },
+
+  // Local like update: the opt-in unattended updater, off until turned on.
+  async autoupdate() {
+    const { values, positionals } = parseArgs({
+      args: rest,
+      options: { at: { type: 'string' } },
+      allowPositionals: true,
+    })
+    const flag = { on: '--enable', off: '--disable', status: '--status' }[positionals[0]]
+    if (!flag) fail(USAGE)
+    const script = resolve(dirname(fileURLToPath(import.meta.url)), '../install/auto-update.sh')
+    const args = [script, flag]
+    if (values.at) args.push('--at', values.at)
+    const { status, error } = spawnSync('bash', args, { stdio: 'inherit' })
     if (error) fail(error.message)
     process.exit(status ?? 1)
   },

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -73,7 +73,7 @@ easel autoupdate status        # on / off / unset
 
 What each run does, and refuses to do:
 
-- **Fast-forward only, default branch only, clean tree only.** A dirty checkout, a feature branch, or a diverged history (a force-push, say) is a situation for a human; each is skipped and logged, never resolved unattended.
+- **Fast-forward only, default branch only, clean tree only.** A dirty checkout, a feature branch, or a diverged history (a force-push, say) is a situation for a human; each is skipped and logged, never resolved unattended. The branch must also track `origin/<default>` itself — a default-named branch tracking a fork is refused, so an unattended update cannot install from outside the remote you think it is following.
 - **Nothing new, nothing touched.** When the checkout is already current it exits without reinstalling or restarting anything, so an enabled updater does not drop your live board tabs once a day for no reason.
 - **One update path.** An actual update delegates to the same `install/update.sh` → `install.sh` converge that a manual `easel update` uses, so auto and manual cannot drift apart.
 - **A written record.** Every run appends to `~/.easel/auto-update.log`: timestamp, verdict, the incoming commit subjects logged before they land, and the range that actually landed logged after — so an origin that moves mid-update cannot leave unlogged code running. "What changed on this machine, and when" always has an answer.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,7 +76,7 @@ What each run does, and refuses to do:
 - **Fast-forward only, default branch only, clean tree only.** A dirty checkout, a feature branch, or a diverged history (a force-push, say) is a situation for a human; each is skipped and logged, never resolved unattended.
 - **Nothing new, nothing touched.** When the checkout is already current it exits without reinstalling or restarting anything, so an enabled updater does not drop your live board tabs once a day for no reason.
 - **One update path.** An actual update delegates to the same `install/update.sh` → `install.sh` converge that a manual `easel update` uses, so auto and manual cannot drift apart.
-- **A written record.** Every run appends to `~/.easel/auto-update.log`: timestamp, verdict, and the incoming commit subjects logged before they land. "What changed on this machine, and when" always has an answer.
+- **A written record.** Every run appends to `~/.easel/auto-update.log`: timestamp, verdict, the incoming commit subjects logged before they land, and the range that actually landed logged after — so an origin that moves mid-update cannot leave unlogged code running. "What changed on this machine, and when" always has an answer.
 
 What it does **not** do: verify anything beyond your clone's `origin` remote over its existing transport. If your trust model wants review-before-run, signature checks, or a canary period, that is precisely the write-your-own exercise above.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,6 +11,8 @@ install/install.sh
 
 Idempotent — re-running converges to the same state. It writes `~/Library/LaunchAgents/com.sentience.easeld.plist` (derived from the clone's own location, never a hardcoded path), bootstraps the agent, puts an `easel` entry point on PATH, and waits for `/health`.
 
+Nothing updates itself after this: upgrading is `easel update`, manual by design, and the opt-in alternative is `easel autoupdate on` — [Auto-update](#auto-update) explains what it does and why it is not the default.
+
 `install.sh --uninstall` boots the agent out, removes the plist, and removes the entry point.
 
 **It deliberately leaves `~/.easel/` alone** — your boards, sources, whiteboards, and `easel.db` all survive an uninstall, so reinstalling later picks up exactly where you left off. Nothing prompts you about this, so if you meant to erase everything, that is a second, separate step:
@@ -54,6 +56,29 @@ easel update
 Pulls the installed checkout (`--ff-only`), reinstalls deps, rebuilds the excalidraw bundle, then re-runs `install.sh` — so plist/launcher/shim changes shipped by the pull actually converge — preserving the installed port, state dir, and node pin, and waits for `/health` on the installed port. It always targets the checkout the CLI shim was installed from — never your dev worktree — so the daemon's home can be a dedicated clone (e.g. `~/.easel/app`) that no development ever touches. To move the daemon's home, clone anywhere and re-run `install.sh` from the new clone; the shim and plist converge to it.
 
 **A verification done without that restart is invalid, and it fails in a way that looks like success:** the old template renders without erroring, so the board just quietly shows the pre-change behaviour. Publishing through `--template` after a kickstart is the check that actually exercises the daemon's template path — publishing pre-rendered HTML does not, because that path never loads a template at all.
+
+### Auto-update
+
+Off by default, and that is a position, not an omission. easel ships enhancements regularly and `easel update` is the whole upgrade — but an auto-updater is standing permission to execute whatever the remote ships next: `git pull` brings new code, `npm install` runs dependency lifecycle scripts, and the daemon restarts into all of it, unattended. A tool your agents drive deserves to have that decision made consciously, so nothing here installs itself until you say so.
+
+Worth saying before describing the shipped one: **writing your own auto-updater is a good first exercise in AI-security hygiene.** The questions it forces — which remote do I trust, what checks does new code pass before it runs on my machine, what may run at install time, where is the record of what changed — are exactly the questions worth asking of every agent-adjacent tool you allow to modify itself. A short shell script and a launchd plist will do it, and `install/auto-update.sh` is a readable reference.
+
+The shipped one:
+
+```
+easel autoupdate on            # daily, 10:00 by default; --at HH:MM picks the time
+easel autoupdate off           # removes the agent and records the choice, so agents stop suggesting it
+easel autoupdate status        # on / off / unset
+```
+
+What each run does, and refuses to do:
+
+- **Fast-forward only, default branch only, clean tree only.** A dirty checkout, a feature branch, or a diverged history (a force-push, say) is a situation for a human; each is skipped and logged, never resolved unattended.
+- **Nothing new, nothing touched.** When the checkout is already current it exits without reinstalling or restarting anything, so an enabled updater does not drop your live board tabs once a day for no reason.
+- **One update path.** An actual update delegates to the same `install/update.sh` → `install.sh` converge that a manual `easel update` uses, so auto and manual cannot drift apart.
+- **A written record.** Every run appends to `~/.easel/auto-update.log`: timestamp, verdict, and the incoming commit subjects logged before they land. "What changed on this machine, and when" always has an answer.
+
+What it does **not** do: verify anything beyond your clone's `origin` remote over its existing transport. If your trust model wants review-before-run, signature checks, or a canary period, that is precisely the write-your-own exercise above.
 
 ## The loop
 

--- a/install/auto-update.sh
+++ b/install/auto-update.sh
@@ -74,6 +74,12 @@ plan_update() {
   default="${default#origin/}"; [ -n "$default" ] || default=main
   [ "$branch" = "$default" ] || { echo "skip: on $branch, not $default"; return; }
   git fetch --quiet origin 2>/dev/null || { echo "skip: fetch failed"; return; }
+  # update.sh's bare `git pull` follows the configured upstream, so the branch
+  # tracking anything but origin/<default> would install from outside origin.
+  local upstream_ref
+  upstream_ref="$(git rev-parse --symbolic-full-name '@{u}' 2>/dev/null)" || { echo "skip: no upstream"; return; }
+  [ "$upstream_ref" = "refs/remotes/origin/$default" ] \
+    || { echo "skip: upstream is $upstream_ref, not origin/$default"; return; }
   upstream="$(git rev-parse '@{u}' 2>/dev/null)" || { echo "skip: no upstream"; return; }
   head="$(git rev-parse HEAD)"
   [ "$head" != "$upstream" ] || { echo "current $(git rev-parse --short HEAD)"; return; }
@@ -103,11 +109,12 @@ run() {
   case "$plan" in update\ *) ;; *) exit 0 ;; esac
   # The incoming commits, logged before they land — the log is the audit trail.
   git -C "$ROOT" log --oneline 'HEAD..@{u}' | sed 's/^/  + /'
-  local before; before="$(cut -d' ' -f2 <<<"$plan")"
-  bash "$ROOT/install/update.sh"
-  # update.sh pulls again, so origin may have moved past the plan — record what
-  # actually landed, or the trail could omit code that is now running.
+  local before rc=0; before="$(cut -d' ' -f2 <<<"$plan")"
+  # Failure still leaves a pull landed and lifecycle scripts run, so the range is
+  # logged either way — update.sh pulls again and origin may have moved past the plan.
+  bash "$ROOT/install/update.sh" || rc=$?
   echo "landed:"; git -C "$ROOT" log --oneline "$before..HEAD" | sed 's/^/  = /'
+  [ "$rc" -eq 0 ] || { echo "== failed rc=$rc $(stamp)"; exit "$rc"; }
   echo "== done $(stamp)"
 }
 

--- a/install/auto-update.sh
+++ b/install/auto-update.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Opt-in unattended updater. --run is what launchd invokes on the schedule;
+# --enable/--disable/--status manage the agent. Off until a human turns it on.
+set -euo pipefail
+
+LABEL="com.sentience.easeld-update"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="${EASEL_DATA_DIR:-$HOME/.easel}"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+TEMPLATE="$ROOT/install/$LABEL.plist.template"
+LOG="$STATE_DIR/auto-update.log"
+# The marker means "asked and declined" — its absence is what tells an agent
+# the user has never chosen, so it must survive --disable and uninstall.
+OPTOUT="$STATE_DIR/auto-update.off"
+
+say() { printf '  %s\n' "$*"; }
+stamp() { date '+%Y-%m-%d %H:%M:%S'; }
+
+usage() {
+  cat <<EOF
+usage: auto-update.sh --enable [--at HH:MM] | --disable | --status | --run
+
+  --enable    register a launchd agent that runs one update pass daily (10:00)
+  --disable   remove the agent and record the opt-out
+  --status    print one of: on / off / unset
+  --run       one unattended pass (what the agent invokes; appends to
+              $LOG)
+EOF
+}
+
+# Escaping and teardown live in install.sh; lift them rather than fork them.
+eval "$(sed -n '/^xml_escape() {/,/^}/p;/^subst_value() {/,/^}/p' "$ROOT/install/install.sh")"
+
+# 24h HH:MM into HOUR/MINUTE integers (launchd rejects leading zeros as octal-ish).
+parse_at() {
+  printf '%s' "$1" | grep -qE '^([01]?[0-9]|2[0-3]):[0-5][0-9]$' \
+    || { echo "error: --at wants HH:MM (24h), got: $1" >&2; exit 2; }
+  HOUR=$((10#${1%%:*})); MINUTE=$((10#${1##*:}))
+}
+
+write_agent_plist() {
+  sed -e "s|__LABEL__|$(subst_value "$LABEL")|g" \
+      -e "s|__ROOT__|$(subst_value "$ROOT")|g" \
+      -e "s|__STATE__|$(subst_value "$STATE_DIR")|g" \
+      -e "s|__HOUR__|$HOUR|g" \
+      -e "s|__MINUTE__|$MINUTE|g" \
+      -e "s|__PATH__|$(subst_value "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")|g" \
+      "$TEMPLATE" > "$1"
+}
+
+autoupdate_status() {
+  if [ -f "$PLIST" ]; then
+    local h m
+    h="$(/usr/libexec/PlistBuddy -c 'Print :StartCalendarInterval:Hour' "$PLIST" 2>/dev/null || echo 0)"
+    m="$(/usr/libexec/PlistBuddy -c 'Print :StartCalendarInterval:Minute' "$PLIST" 2>/dev/null || echo 0)"
+    printf 'on — daily at %02d:%02d, log: %s\n' "$h" "$m" "$LOG"
+  elif [ -f "$OPTOUT" ]; then
+    echo "off — declined $(cat "$OPTOUT" 2>/dev/null || true)"
+  else
+    echo "unset — never configured; \`easel autoupdate on\` enables it, docs/usage.md § Auto-update explains it"
+  fi
+}
+
+# The whole unattended policy in one function, printed as a single verdict line
+# so --run can act on it and tests can assert it without touching launchd.
+plan_update() {
+  cd "$ROOT"
+  [ -z "$(git status --porcelain 2>/dev/null)" ] || { echo "skip: working tree dirty"; return; }
+  local branch default upstream head
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || { echo "skip: not a git checkout"; return; }
+  default="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  default="${default#origin/}"; [ -n "$default" ] || default=main
+  [ "$branch" = "$default" ] || { echo "skip: on $branch, not $default"; return; }
+  git fetch --quiet origin 2>/dev/null || { echo "skip: fetch failed"; return; }
+  upstream="$(git rev-parse '@{u}' 2>/dev/null)" || { echo "skip: no upstream"; return; }
+  head="$(git rev-parse HEAD)"
+  [ "$head" != "$upstream" ] || { echo "current $(git rev-parse --short HEAD)"; return; }
+  git merge-base --is-ancestor HEAD "$upstream" || { echo "skip: history diverged"; return; }
+  echo "update $(git rev-parse --short HEAD) $(git rev-parse --short "$upstream")"
+}
+
+run() {
+  mkdir -p "$STATE_DIR"
+  exec >>"$LOG" 2>&1
+  echo "== $(stamp)"
+  # Honor an installed node pin the same way update.sh does.
+  v="$(/usr/libexec/PlistBuddy -c 'Print :EnvironmentVariables:EASEL_NODE' \
+    "$HOME/Library/LaunchAgents/com.sentience.easeld.plist" 2>/dev/null || true)"
+  [ -n "$v" ] && export EASEL_NODE="${EASEL_NODE:-$v}"
+  # The launcher owns node resolution; lift it so npm/node under launchd are
+  # the same ones the daemon itself would run.
+  eval "$(sed -n '/^resolve_node() {/,/^}/p' "$ROOT/install/easeld-launcher.sh")"
+  local node_bin plan
+  if node_bin="$(resolve_node)"; then
+    PATH="$(dirname "$node_bin"):$PATH"; export PATH
+  else
+    echo "skip: no node interpreter found"; exit 0
+  fi
+  plan="$(plan_update)"
+  echo "$plan"
+  case "$plan" in update\ *) ;; *) exit 0 ;; esac
+  # The incoming commits, logged before they land — the log is the audit trail.
+  git -C "$ROOT" log --oneline 'HEAD..@{u}' | sed 's/^/  + /'
+  bash "$ROOT/install/update.sh"
+  echo "== done $(stamp)"
+}
+
+enable_agent() {
+  mkdir -p "$STATE_DIR" "$(dirname "$PLIST")"
+  local tmp; tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+  write_agent_plist "$tmp"
+  cp "$tmp" "$PLIST"
+  launchctl bootout "gui/$UID/$LABEL" 2>/dev/null || true
+  launchctl bootstrap "gui/$UID" "$PLIST"
+  rm -f "$OPTOUT"
+  printf '== %s enabled — daily at %02d:%02d\n' "$(stamp)" "$HOUR" "$MINUTE" >> "$LOG"
+  say "auto-update on — daily at $(printf '%02d:%02d' "$HOUR" "$MINUTE"), log: $LOG"
+}
+
+disable_agent() {
+  launchctl bootout "gui/$UID/$LABEL" 2>/dev/null || true
+  rm -f "$PLIST"
+  mkdir -p "$STATE_DIR"
+  date '+%Y-%m-%d' > "$OPTOUT"
+  echo "== $(stamp) disabled" >> "$LOG"
+  say "auto-update off — choice recorded, agents will stop suggesting it"
+}
+
+MODE="" AT="10:00"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --enable|--disable|--status|--run) MODE="$1"; shift ;;
+    --at) AT="${2:?--at needs HH:MM}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$MODE" in
+  --enable) parse_at "$AT"; enable_agent ;;
+  --disable) disable_agent ;;
+  --status) autoupdate_status ;;
+  --run) run ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/install/auto-update.sh
+++ b/install/auto-update.sh
@@ -29,7 +29,9 @@ EOF
 }
 
 # Escaping and teardown live in install.sh; lift them rather than fork them.
-eval "$(sed -n '/^xml_escape() {/,/^}/p;/^subst_value() {/,/^}/p' "$ROOT/install/install.sh")"
+# bootout_if_loaded matters here too: launchd teardown is asynchronous, and an
+# immediate re-bootstrap of the same label fails with an I/O error.
+eval "$(sed -n '/^xml_escape() {/,/^}/p;/^subst_value() {/,/^}/p;/^bootout_if_loaded() {/,/^}/p' "$ROOT/install/install.sh")"
 
 # 24h HH:MM into HOUR/MINUTE integers (launchd rejects leading zeros as octal-ish).
 parse_at() {
@@ -101,7 +103,11 @@ run() {
   case "$plan" in update\ *) ;; *) exit 0 ;; esac
   # The incoming commits, logged before they land — the log is the audit trail.
   git -C "$ROOT" log --oneline 'HEAD..@{u}' | sed 's/^/  + /'
+  local before; before="$(cut -d' ' -f2 <<<"$plan")"
   bash "$ROOT/install/update.sh"
+  # update.sh pulls again, so origin may have moved past the plan — record what
+  # actually landed, or the trail could omit code that is now running.
+  echo "landed:"; git -C "$ROOT" log --oneline "$before..HEAD" | sed 's/^/  = /'
   echo "== done $(stamp)"
 }
 
@@ -110,7 +116,7 @@ enable_agent() {
   local tmp; tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
   write_agent_plist "$tmp"
   cp "$tmp" "$PLIST"
-  launchctl bootout "gui/$UID/$LABEL" 2>/dev/null || true
+  bootout_if_loaded
   launchctl bootstrap "gui/$UID" "$PLIST"
   rm -f "$OPTOUT"
   printf '== %s enabled — daily at %02d:%02d\n' "$(stamp)" "$HOUR" "$MINUTE" >> "$LOG"

--- a/install/com.sentience.easeld-update.plist.template
+++ b/install/com.sentience.easeld-update.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>__LABEL__</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__ROOT__/install/auto-update.sh</string>
+    <string>--run</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__ROOT__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>EASEL_DATA_DIR</key>
+    <string>__STATE__</string>
+    <key>PATH</key>
+    <string>__PATH__</string>
+  </dict>
+
+  <!-- No RunAtLoad: enabling must never itself trigger an update. launchd runs
+       a missed interval once on wake, so a sleeping laptop still updates daily. -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>__HOUR__</integer>
+    <key>Minute</key>
+    <integer>__MINUTE__</integer>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>__STATE__/auto-update.log</string>
+  <key>StandardErrorPath</key>
+  <string>__STATE__/auto-update.log</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/install/install.sh
+++ b/install/install.sh
@@ -165,6 +165,13 @@ if [ "$UNINSTALL" -eq 1 ]; then
   bootout_if_loaded
   say "agent booted out"
   if [ -f "$PLIST" ]; then rm -f "$PLIST"; say "removed $PLIST"; else say "no plist at $PLIST"; fi
+  # The auto-update agent rides along; its log and opt-out marker live in
+  # ~/.easel and survive, like everything else there.
+  UPDATE_LABEL="com.sentience.easeld-update"
+  launchctl bootout "gui/$UID/$UPDATE_LABEL" 2>/dev/null || true
+  if [ -f "$PLIST_DIR/$UPDATE_LABEL.plist" ]; then
+    rm -f "$PLIST_DIR/$UPDATE_LABEL.plist"; say "removed the auto-update agent"
+  fi
   LINK_DIRS=("${SWEEP_DIRS[@]}")
   [ -n "$BIN_DIR" ] && LINK_DIRS+=("$BIN_DIR")
   for d in "${LINK_DIRS[@]}"; do

--- a/install/install.sh
+++ b/install/install.sh
@@ -149,6 +149,19 @@ relocate_stale_entries() {
   done
 }
 
+# An enabled updater must follow the root on relocation, or the old checkout's
+# schedule keeps rewriting the plist and shim back to the previous install.
+migrate_updater() {
+  local uplist="$PLIST_DIR/com.sentience.easeld-update.plist" prog h m
+  [ -f "$uplist" ] || return 0
+  prog="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "$uplist" 2>/dev/null || true)"
+  [ "$prog" = "$ROOT/install/auto-update.sh" ] && return 0
+  h="$(/usr/libexec/PlistBuddy -c 'Print :StartCalendarInterval:Hour' "$uplist" 2>/dev/null || echo 10)"
+  m="$(/usr/libexec/PlistBuddy -c 'Print :StartCalendarInterval:Minute' "$uplist" 2>/dev/null || echo 0)"
+  EASEL_DATA_DIR="$STATE_DIR" "$ROOT/install/auto-update.sh" --enable --at "$(printf '%02d:%02d' "$h" "$m")"
+  say "auto-update agent rebound to this checkout"
+}
+
 # An unrelated entry on PATH belongs to someone else, on install and uninstall alike.
 remove_owned_link() {
   local link="$1/$2"
@@ -271,6 +284,8 @@ bootout_if_loaded
 launchctl bootstrap "gui/$UID" "$PLIST"
 launchctl enable "gui/$UID/$LABEL" 2>/dev/null || true
 say "agent bootstrapped: $LABEL"
+
+migrate_updater
 
 printf '  waiting for daemon on port %s' "$PORT"
 ok=0

--- a/skills/easel/SKILL.md
+++ b/skills/easel/SKILL.md
@@ -79,6 +79,10 @@ Applying 3+ annotations: one script that makes every edit, each replacement asse
 
 `easel purge [--older-than 30d]` deletes boards untouched past the cutoff — discretionary, never auto-run. Details: `references/cleanup.md`.
 
+## Auto-update — disclose it once
+
+Updates never install themselves. `easel autoupdate status` printing `unset` means the user has never chosen; the next time setup, upgrading, or daemon health is already the topic, disclose it once, briefly: easel ships enhancements regularly; auto-update is off by default because an auto-updater is standing permission to run whatever the remote ships next, and that grant should be conscious; `easel autoupdate on` enables the shipped one (daily, fast-forward-only, every run logged to `~/.easel/auto-update.log`), and writing their own instead is encouraged as a first exercise in AI-security hygiene — `docs/usage.md` § Auto-update carries the full reasoning. Record their answer — `easel autoupdate on` or `off`, either ends the prompting. Never enable it without their explicit word, and never re-raise after `off`.
+
 ## Gotchas
 
 - Changes under `chrome/`, `render/`, `daemon/`, or `templates/` need `easel update` before the resident daemon serves them; round HTML is baked at publish, so template fixes only show on rounds published after them.

--- a/test/auto-update.test.js
+++ b/test/auto-update.test.js
@@ -1,0 +1,248 @@
+/* Exercises auto-update.sh's policy and generation helpers by extracting them
+   from the shipped script — never runs --enable/--run, which would touch launchd. */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SCRIPT = join(HERE, '..', 'install', 'auto-update.sh')
+const INSTALL = join(HERE, '..', 'install', 'install.sh')
+const LAUNCHER = join(HERE, '..', 'install', 'easeld-launcher.sh')
+const TEMPLATE = join(HERE, '..', 'install', 'com.sentience.easeld-update.plist.template')
+
+/** Pull one `name() { ... }` block out of a script by brace depth. */
+function extract(name, file = SCRIPT) {
+  const lines = readFileSync(file, 'utf8').split('\n')
+  const start = lines.findIndex((l) => l.startsWith(`${name}() {`))
+  assert.notEqual(start, -1, `${file} no longer defines ${name}()`)
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i] === '}') return lines.slice(start, i + 1).join('\n')
+  }
+  assert.fail(`unterminated ${name}() in ${file}`)
+}
+
+const runBash = (script) => execFileSync('bash', ['-c', script], { encoding: 'utf8' })
+
+describe('auto-update.sh: shipped form', () => {
+  test('git tracks it as executable', () => {
+    const out = execFileSync('git', ['ls-files', '-s', 'install/auto-update.sh'], {
+      cwd: join(HERE, '..'),
+      encoding: 'utf8',
+    })
+    assert.match(out, /^100755 /, 'tracked non-executable — a clean checkout cannot exec it')
+  })
+
+  test('parses (bash -n)', () => {
+    execFileSync('bash', ['-n', SCRIPT])
+  })
+
+  /* The script lifts these by sed range instead of forking them; if either
+     source stops matching the range, the lift silently evals nothing. */
+  test('the functions it lifts from install.sh and the launcher still extract', () => {
+    for (const [name, file] of [
+      ['xml_escape', INSTALL],
+      ['subst_value', INSTALL],
+      ['resolve_node', LAUNCHER],
+    ]) {
+      const body = runBash(`sed -n '/^${name}() {/,/^}/p' ${JSON.stringify(file)}`)
+      assert.match(body, new RegExp(`^${name}\\(\\) \\{`), `${name} no longer lifts from ${file}`)
+      execFileSync('bash', ['-n'], { input: body })
+    }
+  })
+})
+
+describe('auto-update.sh: parse_at', () => {
+  const fn = extract('parse_at')
+  const parse = (raw) => runBash(`${fn}\nparse_at ${JSON.stringify(raw)}\necho "$HOUR $MINUTE"`)
+
+  test('accepts 24h times and strips leading zeros for launchd', () => {
+    assert.equal(parse('09:30').trim(), '9 30')
+    assert.equal(parse('0:05').trim(), '0 5')
+    assert.equal(parse('23:59').trim(), '23 59')
+  })
+
+  for (const bad of ['25:00', '10:60', '9', '9:5', 'noon', '10:00pm']) {
+    test(`rejects ${bad}`, () => {
+      assert.throws(() => parse(bad), /wants HH:MM/)
+    })
+  }
+})
+
+describe('auto-update.sh: plan_update', () => {
+  const fn = extract('plan_update')
+
+  /** A bare origin with one commit, and a clone of it on branch main. */
+  const scratch = () => {
+    const box = mkdtempSync(join(tmpdir(), 'easel-auto-'))
+    const origin = join(box, 'origin.git')
+    const clone = join(box, 'clone')
+    const seed = join(box, 'seed')
+    const git = (cwd, ...args) =>
+      execFileSync('git', args, { cwd, encoding: 'utf8', env: { ...process.env, HOME: box } })
+    execFileSync('git', ['init', '--bare', '-b', 'main', origin], { encoding: 'utf8' })
+    mkdirSync(seed)
+    git(seed, 'init', '-b', 'main')
+    git(seed, 'config', 'user.email', 't@t')
+    git(seed, 'config', 'user.name', 't')
+    writeFileSync(join(seed, 'a'), '1\n')
+    git(seed, 'add', 'a')
+    git(seed, 'commit', '-m', 'one')
+    git(seed, 'remote', 'add', 'origin', origin)
+    git(seed, 'push', 'origin', 'main')
+    execFileSync('git', ['clone', origin, clone], { encoding: 'utf8' })
+    git(clone, 'config', 'user.email', 't@t')
+    git(clone, 'config', 'user.name', 't')
+    return { box, origin, clone, seed, git }
+  }
+
+  const plan = (root) => runBash(`ROOT=${JSON.stringify(root)}\n${fn}\nplan_update`).trim()
+
+  test('a current checkout is left alone', () => {
+    const { clone } = scratch()
+    assert.match(plan(clone), /^current [0-9a-f]+$/)
+  })
+
+  test('a checkout behind origin plans an update', () => {
+    const { clone, seed, git } = scratch()
+    writeFileSync(join(seed, 'a'), '2\n')
+    git(seed, 'commit', '-am', 'two')
+    git(seed, 'push', 'origin', 'main')
+    assert.match(plan(clone), /^update [0-9a-f]+ [0-9a-f]+$/)
+  })
+
+  test('a dirty tree is a human situation', () => {
+    const { clone } = scratch()
+    writeFileSync(join(clone, 'a'), 'dirty\n')
+    assert.equal(plan(clone), 'skip: working tree dirty')
+  })
+
+  test('a feature branch is a human situation', () => {
+    const { clone, git } = scratch()
+    git(clone, 'checkout', '-b', 'feature')
+    assert.equal(plan(clone), 'skip: on feature, not main')
+  })
+
+  test('diverged history — a force-push, say — is a human situation', () => {
+    const { clone, seed, git } = scratch()
+    writeFileSync(join(seed, 'a'), '2\n')
+    git(seed, 'commit', '-am', 'two')
+    git(seed, 'push', 'origin', 'main')
+    git(clone, 'commit', '--allow-empty', '-m', 'local divergence')
+    assert.equal(plan(clone), 'skip: history diverged')
+  })
+
+  test('an unreachable origin skips instead of failing', () => {
+    const { clone, origin } = scratch()
+    execFileSync('rm', ['-rf', origin])
+    assert.equal(plan(clone), 'skip: fetch failed')
+  })
+})
+
+describe('auto-update.sh: plist generation', () => {
+  const helpers = [extract('xml_escape', INSTALL), extract('subst_value', INSTALL), extract('write_agent_plist')].join('\n')
+
+  const generate = () => {
+    const box = mkdtempSync(join(tmpdir(), 'easel-auto-plist-'))
+    const out = join(box, 'test.plist')
+    runBash(`
+      LABEL=com.sentience.easeld-update
+      ROOT=/Users/x/repos/easel
+      STATE_DIR=/Users/x/.easel
+      HOUR=9 MINUTE=30
+      TEMPLATE=${JSON.stringify(TEMPLATE)}
+      ${helpers}
+      write_agent_plist ${JSON.stringify(out)}
+    `)
+    return out
+  }
+
+  test('every placeholder is substituted and the plist parses', () => {
+    const out = generate()
+    assert.doesNotMatch(readFileSync(out, 'utf8'), /__[A-Z_]+__/)
+    execFileSync('plutil', ['-lint', out], { encoding: 'utf8' })
+  })
+
+  test('the schedule and the --run invocation land', () => {
+    const out = generate()
+    const read = (path) =>
+      execFileSync('plutil', ['-extract', path, 'raw', '-o', '-', out], { encoding: 'utf8' }).trim()
+    assert.equal(read('StartCalendarInterval.Hour'), '9')
+    assert.equal(read('StartCalendarInterval.Minute'), '30')
+    assert.equal(read('ProgramArguments.1'), '--run')
+  })
+
+  test('enabling never itself triggers an update', () => {
+    assert.doesNotMatch(readFileSync(TEMPLATE, 'utf8'), /<key>RunAtLoad<\/key>/)
+  })
+})
+
+describe('auto-update.sh: status', () => {
+  const fn = extract('autoupdate_status')
+
+  const status = ({ plist, optout } = {}) => {
+    const box = mkdtempSync(join(tmpdir(), 'easel-auto-status-'))
+    const plistPath = join(box, 'agent.plist')
+    const optoutPath = join(box, 'auto-update.off')
+    if (plist) {
+      runBash(`
+        LABEL=com.sentience.easeld-update ROOT=/r STATE_DIR=/s HOUR=10 MINUTE=0
+        TEMPLATE=${JSON.stringify(TEMPLATE)}
+        ${[extract('xml_escape', INSTALL), extract('subst_value', INSTALL), extract('write_agent_plist')].join('\n')}
+        write_agent_plist ${JSON.stringify(plistPath)}
+      `)
+    }
+    if (optout) writeFileSync(optoutPath, '2026-08-17\n')
+    return runBash(`
+      PLIST=${JSON.stringify(plistPath)}
+      OPTOUT=${JSON.stringify(optoutPath)}
+      LOG=/s/auto-update.log
+      ${fn}
+      autoupdate_status
+    `).trim()
+  }
+
+  test('never configured reads as unset — what tells an agent to disclose once', () => {
+    assert.match(status(), /^unset/)
+  })
+
+  test('a recorded decline reads as off, with the date', () => {
+    assert.match(status({ optout: true }), /^off — declined 2026-08-17/)
+  })
+
+  test('an installed agent reads as on, with its schedule', () => {
+    assert.match(status({ plist: true }), /^on — daily at 10:00/)
+  })
+
+  test('a decline never shadows an installed agent', () => {
+    assert.match(status({ plist: true, optout: true }), /^on/)
+  })
+})
+
+describe('wiring', () => {
+  test('uninstall also removes the auto-update agent', () => {
+    const src = readFileSync(INSTALL, 'utf8')
+    assert.match(src, /com\.sentience\.easeld-update/, 'install.sh --uninstall would orphan the update agent')
+  })
+
+  test('the CLI exposes autoupdate and routes it to the script', () => {
+    const cli = readFileSync(join(HERE, '..', 'cli', 'easel.js'), 'utf8')
+    assert.match(cli, /easel autoupdate on \[--at HH:MM\] \| off \| status/)
+    assert.match(cli, /auto-update\.sh/)
+  })
+
+  test('an unknown subcommand fails with usage, not a launchd call', () => {
+    assert.throws(
+      () => execFileSync('node', [join(HERE, '..', 'cli', 'easel.js'), 'autoupdate', 'bogus'], { encoding: 'utf8' }),
+      (err) => {
+        assert.equal(err.status, 1)
+        assert.match(String(err.stderr), /autoupdate on/)
+        return true
+      },
+    )
+  })
+})

--- a/test/auto-update.test.js
+++ b/test/auto-update.test.js
@@ -41,12 +41,25 @@ describe('auto-update.sh: shipped form', () => {
     execFileSync('bash', ['-n', SCRIPT])
   })
 
+  /* update.sh pulls again after the incoming range was logged, so a moving
+     origin can land more than was promised — the landed range must be recorded. */
+  test('a run records the landed range, not only the planned one', () => {
+    const body = extract('run')
+    assert.match(body, /landed:/)
+    assert.match(body, /\$before\.\.HEAD/)
+  })
+
+  test('enable waits out launchd teardown before bootstrapping again', () => {
+    assert.match(extract('enable_agent'), /bootout_if_loaded/)
+  })
+
   /* The script lifts these by sed range instead of forking them; if either
      source stops matching the range, the lift silently evals nothing. */
   test('the functions it lifts from install.sh and the launcher still extract', () => {
     for (const [name, file] of [
       ['xml_escape', INSTALL],
       ['subst_value', INSTALL],
+      ['bootout_if_loaded', INSTALL],
       ['resolve_node', LAUNCHER],
     ]) {
       const body = runBash(`sed -n '/^${name}() {/,/^}/p' ${JSON.stringify(file)}`)
@@ -220,6 +233,73 @@ describe('auto-update.sh: status', () => {
 
   test('a decline never shadows an installed agent', () => {
     assert.match(status({ plist: true, optout: true }), /^on/)
+  })
+})
+
+describe('install.sh: migrate_updater', () => {
+  const fn = extract('migrate_updater', INSTALL)
+  const genHelpers = [extract('xml_escape', INSTALL), extract('subst_value', INSTALL), extract('write_agent_plist')].join('\n')
+
+  /** A fake root whose auto-update.sh just records how it was called. */
+  const fakeRoot = (box, name) => {
+    const root = join(box, name)
+    mkdirSync(join(root, 'install'), { recursive: true })
+    const stub = join(root, 'install', 'auto-update.sh')
+    writeFileSync(stub, `#!/bin/sh\necho "$@" > ${JSON.stringify(join(box, 'stub-args'))}\n`, { mode: 0o755 })
+    return root
+  }
+
+  const migrate = ({ plistRoot, installRoot }) => {
+    const box = mkdtempSync(join(tmpdir(), 'easel-migrate-'))
+    const plistDir = join(box, 'LaunchAgents')
+    mkdirSync(plistDir)
+    const oldRoot = fakeRoot(box, 'old')
+    const newRoot = fakeRoot(box, 'new')
+    const roots = { old: oldRoot, new: newRoot }
+    runBash(`
+      LABEL=com.sentience.easeld-update
+      ROOT=${JSON.stringify(roots[plistRoot])}
+      STATE_DIR=/s HOUR=9 MINUTE=30
+      TEMPLATE=${JSON.stringify(TEMPLATE)}
+      ${genHelpers}
+      write_agent_plist ${JSON.stringify(join(plistDir, 'com.sentience.easeld-update.plist'))}
+    `)
+    const out = runBash(`
+      say() { printf '  %s\\n' "$*"; }
+      PLIST_DIR=${JSON.stringify(plistDir)}
+      ROOT=${JSON.stringify(roots[installRoot])}
+      STATE_DIR=/s
+      ${fn}
+      migrate_updater
+    `)
+    let stubArgs = null
+    try { stubArgs = readFileSync(join(box, 'stub-args'), 'utf8').trim() } catch { /* not called */ }
+    return { out, stubArgs }
+  }
+
+  test('rebinds an updater left pointing at a previous checkout, keeping its schedule', () => {
+    const { out, stubArgs } = migrate({ plistRoot: 'old', installRoot: 'new' })
+    assert.equal(stubArgs, '--enable --at 09:30')
+    assert.match(out, /rebound/)
+  })
+
+  test('leaves an updater already bound to this checkout alone', () => {
+    const { stubArgs } = migrate({ plistRoot: 'new', installRoot: 'new' })
+    assert.equal(stubArgs, null, 're-bootstrapped an updater that did not move')
+  })
+
+  test('is a no-op when auto-update was never enabled', () => {
+    const box = mkdtempSync(join(tmpdir(), 'easel-migrate-'))
+    mkdirSync(join(box, 'LaunchAgents'))
+    const out = runBash(`
+      say() { printf '  %s\\n' "$*"; }
+      PLIST_DIR=${JSON.stringify(join(box, 'LaunchAgents'))}
+      ROOT=/nowhere
+      STATE_DIR=/s
+      ${fn}
+      migrate_updater
+    `)
+    assert.equal(out.trim(), '')
   })
 })
 

--- a/test/auto-update.test.js
+++ b/test/auto-update.test.js
@@ -53,6 +53,16 @@ describe('auto-update.sh: shipped form', () => {
     assert.match(extract('enable_agent'), /bootout_if_loaded/)
   })
 
+  /* A failed install still leaves the pull landed and lifecycle scripts run, so
+     the range must be logged before the failure propagates. */
+  test('the landed range is logged even when update.sh fails', () => {
+    const body = extract('run')
+    const landed = body.indexOf('landed:')
+    const propagate = body.indexOf('rc=$rc')
+    assert.match(body, /update\.sh" \|\| rc=\$\?/, 'update.sh failure aborts before the range is logged')
+    assert.ok(landed > 0 && propagate > landed, 'failure propagates before the landed range is written')
+  })
+
   /* The script lifts these by sed range instead of forking them; if either
      source stops matching the range, the lift silently evals nothing. */
   test('the functions it lifts from install.sh and the launcher still extract', () => {
@@ -147,6 +157,18 @@ describe('auto-update.sh: plan_update', () => {
     git(seed, 'push', 'origin', 'main')
     git(clone, 'commit', '--allow-empty', '-m', 'local divergence')
     assert.equal(plan(clone), 'skip: history diverged')
+  })
+
+  /* update.sh's bare `git pull` follows the configured upstream, so tracking a
+     fork would install code from outside the documented origin trust boundary. */
+  test('a branch tracking something other than origin/<default> is refused', () => {
+    const { box, clone, git } = scratch()
+    const fork = join(box, 'fork.git')
+    execFileSync('git', ['clone', '--bare', clone, fork], { encoding: 'utf8' })
+    git(clone, 'remote', 'add', 'fork', fork)
+    git(clone, 'fetch', 'fork')
+    git(clone, 'branch', '--set-upstream-to=fork/main', 'main')
+    assert.equal(plan(clone), 'skip: upstream is refs/remotes/fork/main, not origin/main')
   })
 
   test('an unreachable origin skips instead of failing', () => {


### PR DESCRIPTION
## What

An opt-in unattended updater, plus the disclosure around it. Nothing changes for anyone who does not turn it on.

```
easel autoupdate on            # daily, 10:00 by default; --at HH:MM picks the time
easel autoupdate off           # removes the agent and records the choice
easel autoupdate status        # on / off / unset
```

## Why off by default

easel ships enhancements regularly, but an auto-updater is standing permission to execute whatever the remote ships next — `git pull` brings code, `npm install` runs dependency lifecycle scripts, and the daemon restarts into all of it, unattended. That grant should be conscious, so it is a choice and never a default. The docs also encourage writing your own updater as a first exercise in AI-security hygiene, with `install/auto-update.sh` as a readable reference; `docs/usage.md` § Auto-update carries the full reasoning.

## How the shipped one behaves

- **Fast-forward only, default branch only, clean tree only** — a dirty tree, feature branch, or diverged history (force-push) is skipped and logged, never resolved unattended. The whole policy is one function (`plan_update`) printing one verdict line.
- **Nothing new, nothing touched** — when current it exits without reinstalling or restarting, so live board tabs are not dropped daily for no reason.
- **One update path** — a real update delegates to the same `update.sh` → `install.sh` converge as manual `easel update`; auto and manual cannot drift.
- **Audit trail** — every run appends timestamp, verdict, and the incoming commit subjects to `~/.easel/auto-update.log` *before* they land.
- **Enabling never itself updates** — no `RunAtLoad`; launchd's `StartCalendarInterval` coalesces missed runs on wake.
- Node resolution and XML-escaping are **lifted from the launcher and install.sh by sed range** rather than forked, and a test pins the extraction so it cannot silently rot.

## The disclosure flow

- `unset` (never configured) is a distinct status from `off` (declined, recorded in `~/.easel/auto-update.off`).
- `SKILL.md` tells agents: when status is `unset` and setup/health is already the topic, disclose once — what it is, why it is off, the write-your-own encouragement — record the answer, never enable without the user's word, never re-raise after `off`.
- `install.sh --uninstall` removes the agent too; the log and opt-out marker survive in `~/.easel` like everything else there.

## Tests

`test/auto-update.test.js`, 26 tests in the `install.test.js` style (extract-by-name, never touches launchd): the full `plan_update` policy against scratch git remotes (current / behind / dirty / feature branch / diverged / unreachable origin), `parse_at` validation, plist generation through `plutil`, status derivation, uninstall + CLI wiring. Full suite: 680 pass / 0 fail.

Live-verified: `easel autoupdate status` → `unset`; a real `--run` pass resolved node, appended to the log, and refused a dirty tree. Enabling the launchd agent was deliberately **not** exercised on this machine — which is the feature's own point.
