### PR TITLE
A successful enable must exit 0

### DIFF
--- a/install/auto-update.sh
+++ b/install/auto-update.sh
@@ -120,9 +120,11 @@ run() {
 
 enable_agent() {
   mkdir -p "$STATE_DIR" "$(dirname "$PLIST")"
-  local tmp; tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
-  write_agent_plist "$tmp"
-  cp "$tmp" "$PLIST"
+  # Not local: the EXIT trap runs after this function returns, and `set -u`
+  # aborts on the out-of-scope name — which failed a successful enable.
+  TMP_PLIST="$(mktemp)"; trap 'rm -f "$TMP_PLIST"' EXIT
+  write_agent_plist "$TMP_PLIST"
+  cp "$TMP_PLIST" "$PLIST"
   bootout_if_loaded
   launchctl bootstrap "gui/$UID" "$PLIST"
   rm -f "$OPTOUT"

--- a/test/auto-update.test.js
+++ b/test/auto-update.test.js
@@ -4,7 +4,7 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { readFileSync, mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { readFileSync, mkdtempSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -255,6 +255,50 @@ describe('auto-update.sh: status', () => {
 
   test('a decline never shadows an installed agent', () => {
     assert.match(status({ plist: true, optout: true }), /^on/)
+  })
+})
+
+/* Runs the real enable path with launchctl stubbed. The unit tests above all
+   exercised helpers, so a `set -u` abort in enable_agent itself reached a user. */
+describe('auto-update.sh: enable_agent', () => {
+  const run = () => {
+    const box = mkdtempSync(join(tmpdir(), 'easel-enable-'))
+    const bin = join(box, 'bin')
+    mkdirSync(bin)
+    writeFileSync(join(bin, 'launchctl'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    const out = execFileSync(
+      'bash',
+      ['-c', `
+        set -euo pipefail
+        PATH=${JSON.stringify(bin)}:$PATH
+        LABEL=com.sentience.easeld-update
+        ROOT=${JSON.stringify(join(HERE, '..'))}
+        STATE_DIR=${JSON.stringify(join(box, 'state'))}
+        PLIST=${JSON.stringify(join(box, 'agent.plist'))}
+        OPTOUT=${JSON.stringify(join(box, 'state', 'auto-update.off'))}
+        LOG=${JSON.stringify(join(box, 'state', 'auto-update.log'))}
+        TEMPLATE=${JSON.stringify(TEMPLATE)}
+        HOUR=10 MINUTE=0
+        say() { printf '  %s\\n' "$*"; }
+        stamp() { echo now; }
+        bootout_if_loaded() { :; }
+        ${[extract('xml_escape', INSTALL), extract('subst_value', INSTALL), extract('write_agent_plist'), extract('enable_agent')].join('\n')}
+        enable_agent
+      `],
+      { encoding: 'utf8' },
+    )
+    return { out, box }
+  }
+
+  test('exits clean and writes a valid plist — the EXIT trap must not abort it', () => {
+    const { out, box } = run()
+    assert.match(out, /auto-update on — daily at 10:00/)
+    execFileSync('plutil', ['-lint', join(box, 'agent.plist')], { encoding: 'utf8' })
+  })
+
+  test('clears a recorded opt-out', () => {
+    const { box } = run()
+    assert.ok(!existsSync(join(box, 'state', 'auto-update.off')))
   })
 })
 


### PR DESCRIPTION
## What

`easel autoupdate on` installed and loaded the agent correctly, then exited **1** with `tmp: unbound variable`.

`enable_agent` declared `local tmp` but registered `trap 'rm -f "$tmp"' EXIT`. The trap runs after the function returns, so the name is out of scope and `set -u` aborts — after all the real work has already succeeded. Two further `$tmp` references would also have written the plist to an empty path.

Fixed by using a script-scope `TMP_PLIST`, matching `install.sh`'s existing pattern.

## Why it got through #14

Every test in that PR exercised an extracted *helper* — `plan_update`, `parse_at`, `write_agent_plist`, `autoupdate_status`, `migrate_updater`. Nothing ran `enable_agent` itself, because it calls `launchctl`, and the launchd agent was deliberately never enabled on the dev machine while reviewing the PR. The bug surfaced the first time the real command ran.

The new test closes that: it runs the real `enable_agent` with `launchctl` stubbed onto PATH and a scratch state dir, asserting a clean exit and a `plutil`-valid plist. **Verified it fails against the pre-fix script** (2 failures) and passes after.

## Verification

- Full suite **689 pass / 0 fail**.
- Real `easel autoupdate on --at 10:00` → exit 0, `status` → `on — daily at 10:00`, agent loaded in launchd. This also exercises the reconverge path (re-running `on` against an already-loaded agent), which is what `bootout_if_loaded` guards.
