### PR TITLE
Refuse to publish a queue entry that carries a resolution while still open

### DIFF
--- a/templates/queue.js
+++ b/templates/queue.js
@@ -35,6 +35,11 @@ function validateEntry(e, i) {
   if (status === 'open' && kind !== 'merge' && !e.body && !e.context_link) {
     fail(`${path} is an open ${kind} with no body and no context_link — the reader would be voting on one sentence; attach the brief or link the board that holds it`)
   }
+  if (e.resolution !== undefined) requireString(e.resolution, `${path}.resolution`)
+  if (e.resolved_at !== undefined) requireString(e.resolved_at, `${path}.resolved_at`)
+  if (status === 'open' && (e.resolution !== undefined || e.resolved_at !== undefined)) {
+    fail(`${path} carries a resolution but is still status "open", so it renders under "Waiting on you" as though nobody had answered it — set status to "answered"`)
+  }
   if (e.options !== undefined && requireArray(e.options, `${path}.options`).length === 0) {
     fail(`${path}.options must not be empty — omit it for the approve/reject/discuss default`)
   }

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -948,6 +948,27 @@ describe('queue', () => {
     assert.doesNotThrow(() => queue.render(data))
   })
 
+  test('a resolution on a still-open entry throws — that is how a board goes stale', async () => {
+    const data = await base()
+    data.entries[0].resolution = 'Approved — shipped in the follow-up PR.'
+    assert.throws(() => queue.render(data), (err) => {
+      assert.ok(err instanceof TemplateError)
+      assert.match(err.message, /still status "open"/)
+      return true
+    })
+    data.entries[0].status = 'answered'
+    assert.doesNotThrow(() => queue.render(data))
+  })
+
+  test('resolved_at alone also throws, and an answered entry may carry both', async () => {
+    const data = await base()
+    data.entries[0].resolved_at = '2026-08-18T00:00:00Z'
+    assert.throws(() => queue.render(data), TemplateError)
+    data.entries[0].status = 'answered'
+    data.entries[0].resolution = 'Answered on the board.'
+    assert.doesNotThrow(() => queue.render(data))
+  })
+
   test('a seeded board with empty sections still renders', async () => {
     const html = queue.render({ campaign: 'fresh-campaign', entries: [], review_stamps: [], open_prs: [] })
     assert.ok(html.includes('Nothing waiting.'))


### PR DESCRIPTION
## The problem

A queue entry's answered-ness was encoded twice and independently: the `status` field decides which section it renders in, while `resolution` / `resolved_at` hold the answer text. The template partitions "Waiting on you" purely on `status` and never looks at the other two, so writing a resolution and forgetting to flip `status` produces a board that shows answered questions as still waiting — with no error, no warning, nothing.

That is not a hypothetical. A live decision queue showed three already-answered items sitting in "Waiting on you", two of them for ~42 hours, until the owner asked whether the board was stale. The same slip had happened four times on that board, because the only thing preventing it was remembering.

## The fix

`validateEntry` now rejects `status: "open"` together with a `resolution` or `resolved_at`, at publish time — the moment the mistake is made, rather than whenever someone notices the board lying. It matches the validator's existing habit of failing on a semantically-contradictory entry (an open decision with no body and no context_link already throws).

`resolution` and `resolved_at` also get the type checks the other optional string fields have.

## Verification

- Full suite: 691 pass, 0 fail.
- Both new tests mutation-checked — with the guard disabled they go red (109 pass / 2 fail), restored they pass.
- Replayed against the real board that prompted this: the guard catches the actual stale entry.

```
queue.entries[17] carries a resolution but is still status "open", so it renders
under "Waiting on you" as though nobody had answered it — set status to "answered"
```

## Not covered

An entry the author never touches at all — the owner clicks a widget and the author records nothing — still goes stale, and this guard cannot see it. The daemon does know the widget id of every answer it received, so a stronger check ("this entry has a recorded answer but is still open") is possible; it needs feedback history at render time, so it is a separate change.