### PR TITLE
Print the reader checks after every publish

### DIFF
--- a/cli/easel.js
+++ b/cli/easel.js
@@ -6,6 +6,7 @@ import { parseArgs } from 'node:util'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
+import { formatFindings } from '../daemon/reader-checks.js'
 
 const BASE = process.env.EASEL_URL || 'http://127.0.0.1:4400'
 
@@ -129,7 +130,8 @@ const commands = {
       ? `nothing to publish — the source renders identical to round ${d.round}; write your changes to the registered path first (\`easel status ${key}\`)`
       : `published round ${d.round}`) +
       (d.listenerDropped ? `\nyour parked listener was dropped — relaunch \`easel await\`` : '') +
-      (d.audit?.findings?.length ? `\naudit (advisory): ${JSON.stringify(d.audit.findings)}` : ''))
+      (d.audit?.findings?.length ? `\naudit (advisory): ${JSON.stringify(d.audit.findings)}` : '') +
+      (d.reader?.length ? '\n' + formatFindings(d.reader) : ''))
   },
 
   async await() {

--- a/daemon/reader-checks.js
+++ b/daemon/reader-checks.js
@@ -25,7 +25,7 @@ export function readerChecks(html) {
   }
 
   // Shorthand: campaign codes, callsigns, ticket ids and snake_case outside code,
-  // not defined in any table's first column.
+  // not defined in any table cell.
   const prose = html.replace(/<(pre|code)[\s\S]*?<\/\1>/g, ' ')
   const defined = new Set([...html.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/g)].flatMap((m) => strip(m[1]).split(/[,/·]/).map((t) => t.trim())))
   const tokens = new Map()

--- a/daemon/reader-checks.js
+++ b/daemon/reader-checks.js
@@ -1,0 +1,66 @@
+/* What a cold reader trips on, found by pattern on the built html. Advisory
+   only: publish prints each finding with its rule and refuses nothing. */
+
+const strip = (s) => s.replace(/<[^>]+>/g, ' ').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/\s+/g, ' ').trim()
+const words = (s) => strip(s).split(/\s+/).filter(Boolean)
+
+const POINTERS = /\b(see round \d+|as (?:we )?discussed|your round[- ]\d+ ruling|full (?:text|note): \/|section \d+[a-z]? of the (?:approved|earlier)|on the other board)\b/gi
+const RULES = {
+  wall: 'Every paragraph takes the shape of what it is made of (authoring.md)',
+  shorthand: 'Gloss every internal name, the first time it appears (authoring.md)',
+  pointer: 'Restate, never point (authoring.md)',
+  label: 'A decision carries the basis for answering it — the label is two or three words (authoring.md)',
+  formatting: 'Look at the page before announcing it',
+}
+
+export function readerChecks(html) {
+  html = html.replace(/<blockquote[\s\S]*?<\/blockquote>/gi, ' ')
+  const findings = []
+  const add = (type, detail, sample) => findings.push({ type, rule: RULES[type], detail, sample })
+
+  // Walls: a paragraph over ~110 words.
+  for (const m of html.matchAll(/<p(?:\s[^>]*)?>([\s\S]*?)<\/p>/g)) {
+    const w = words(m[1])
+    if (w.length > 110) add('wall', `${w.length}-word paragraph`, w.slice(0, 8).join(' ') + ' …')
+  }
+
+  // Shorthand: campaign codes, callsigns, ticket ids and snake_case outside code,
+  // not defined in any table's first column.
+  const prose = html.replace(/<(pre|code)[\s\S]*?<\/\1>/g, ' ')
+  const defined = new Set([...html.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/g)].flatMap((m) => strip(m[1]).split(/[,/·]/).map((t) => t.trim())))
+  const tokens = new Map()
+  for (const m of strip(prose).matchAll(/\b([A-Z]{2,5}-\d{1,4}|[a-z]{2}-[a-z]\d|[a-z]+_[a-z_]+[a-z]|[A-Z][A-Z0-9]{2,}(?:-[A-Z0-9]+)+)\b/g)) {
+    const t = m[1]
+    if ([...defined].some((d) => d.includes(t))) continue
+    tokens.set(t, (tokens.get(t) ?? 0) + 1)
+  }
+  if (tokens.size) add('shorthand', `${tokens.size} undefined token${tokens.size > 1 ? 's' : ''}`, [...tokens.keys()].slice(0, 8).join(', '))
+
+  // Pointers.
+  const pointers = [...strip(prose).matchAll(POINTERS)].map((m) => m[0])
+  if (pointers.length) add('pointer', `${pointers.length} pointer${pointers.length > 1 ? 's' : ''} to content not on this round`, [...new Set(pointers)].slice(0, 5).join(' · '))
+
+  // Labels: a button over five words.
+  for (const m of html.matchAll(/<button[^>]*data-option="[^"]*"[^>]*>([\s\S]*?)<\/button>/g)) {
+    const w = words(m[1])
+    if (w.length > 5) add('label', `${w.length}-word button`, w.slice(0, 8).join(' ') + ' …')
+  }
+
+  // Formatting bugs.
+  const escaped = (html.match(/&lt;(br|details|summary|b|i|p)\b/g) || []).length
+  if (escaped) add('formatting', `${escaped} html tag${escaped > 1 ? 's' : ''} printed as text`, (html.match(/&lt;[a-z]+[^&]{0,20}/) || [''])[0])
+  const placeholders = html.match(/\{[A-Z_]{2,}\}/g)
+  if (placeholders) add('formatting', `${placeholders.length} unfilled placeholder${placeholders.length > 1 ? 's' : ''}`, [...new Set(placeholders)].slice(0, 5).join(' '))
+  const bare = [...strip(prose.replace(/<a\b[\s\S]*?<\/a>/g, ' ')).matchAll(/(?<![\w/])#\d{3,5}\b/g)].map((m) => m[0])
+  if (bare.length) add('formatting', `${bare.length} PR number${bare.length > 1 ? 's' : ''} with no link`, [...new Set(bare)].slice(0, 6).join(' '))
+  const dashRows = (html.match(/<tr>(?:<td[^>]*>\s*[—–-]\s*<\/td>){2,}<\/tr>/g) || []).length
+  if (dashRows) add('formatting', `${dashRows} table row${dashRows > 1 ? 's' : ''} of only dashes`, '')
+
+  return findings
+}
+
+/** The publish-output shape: one line per finding, rule first. Returns '' when clean. */
+export function formatFindings(findings) {
+  if (!findings.length) return ''
+  return 'reader checks:\n' + findings.map((f) => `• ${f.detail}${f.sample ? ` — "${f.sample}"` : ''}\n    rule: ${f.rule}`).join('\n')
+}

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -14,6 +14,7 @@ import { now, DATA_DIR } from './db.js'
 import { annotateAndDiff, contextForSid, excerptForSid, extractIslands } from './differ.js'
 import { markdown } from '../templates/_html.js'
 import { ROUTES } from './routes.js'
+import { readerChecks } from './reader-checks.js'
 
 const PORT = Number(process.env.EASEL_PORT || 4400)
 const ROOT = dirname(fileURLToPath(import.meta.url))
@@ -812,17 +813,19 @@ async function handlePublish(req, res, match) {
       listenerDropped,
       diff: { added: [], removed: [], modified: [], moved: [] },
       audit: null,
+      reader: null,
     })
   }
   const seq = (last?.seq ?? 0) + 1
   const audit = auditHtml(sidHtml)
+  const reader = readerChecks(sidHtml)
   store.addRound(board.key, seq, sidHtml, body.note ?? null, diff, audit, rendered.diagrams, islands)
   store.setAudit(board.key, audit)
   store.setWip(board.key, null)
   broadcast(board.key, 'round', { seq })
   maybeAutoOpen(board.key)
   const listenerDropped = dropAgentWaiter(board.key, body.agent)
-  json(res, 200, { round: seq, listenerDropped, diff: diff ?? { added: [], removed: [], modified: [], moved: [] }, audit })
+  json(res, 200, { round: seq, listenerDropped, diff: diff ?? { added: [], removed: [], modified: [], moved: [] }, audit, reader })
 }
 
 async function handleAwait(req, res, match) {

--- a/test/reader-checks.test.js
+++ b/test/reader-checks.test.js
@@ -1,0 +1,161 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readerChecks, formatFindings } from '../daemon/reader-checks.js'
+
+// Helper: a paragraph whose text is exactly n copies of "word".
+const wallP = (n) => `<p>${'word '.repeat(n).trim()}</p>`
+
+describe('wall', () => {
+  test('paragraph over 110 words is flagged', () => {
+    const findings = readerChecks(wallP(112))
+    assert.equal(findings.length, 1)
+    assert.equal(findings[0].type, 'wall')
+    assert.match(findings[0].detail, /112-word paragraph/)
+  })
+
+  test('paragraph at or under 110 words is clean', () => {
+    assert.equal(readerChecks(wallP(110)).length, 0)
+  })
+})
+
+describe('shorthand', () => {
+  test('undefined token in prose is flagged', () => {
+    const html = '<p>APR-01 shipped last week.</p>'
+    const findings = readerChecks(html)
+    assert.equal(findings.length, 1)
+    assert.equal(findings[0].type, 'shorthand')
+    assert.match(findings[0].sample, /APR-01/)
+  })
+
+  test('token defined in any table cell (including second column) is not flagged', () => {
+    // False positive fix: the old code only read the first <td> per row.
+    const html = `
+      <table>
+        <tr><td>Campaign tracker</td><td>APR-01</td></tr>
+      </table>
+      <p>APR-01 shipped last week.</p>`
+    assert.equal(readerChecks(html).filter((f) => f.type === 'shorthand').length, 0)
+  })
+
+  test('token defined in first column is also not flagged', () => {
+    const html = `
+      <table><tr><td>APR-01</td><td>approval queue</td></tr></table>
+      <p>APR-01 shipped last week.</p>`
+    assert.equal(readerChecks(html).filter((f) => f.type === 'shorthand').length, 0)
+  })
+
+  test('token inside a code span is not flagged', () => {
+    const html = '<p>The <code>APR-01</code> handler runs first.</p>'
+    assert.equal(readerChecks(html).filter((f) => f.type === 'shorthand').length, 0)
+  })
+})
+
+describe('pointer', () => {
+  test('"see round N" phrase is flagged', () => {
+    const html = '<p>For details see round 9.</p>'
+    const findings = readerChecks(html)
+    assert.equal(findings.length, 1)
+    assert.equal(findings[0].type, 'pointer')
+  })
+
+  test('"full text: /" phrase is flagged', () => {
+    const html = '<p>Full text: /data/file.txt</p>'
+    const findings = readerChecks(html).filter((f) => f.type === 'pointer')
+    assert.equal(findings.length, 1)
+  })
+})
+
+describe('label', () => {
+  test('button over five words is flagged', () => {
+    const html = '<button data-option="a">Approve as written with changes today</button>'
+    const findings = readerChecks(html)
+    assert.equal(findings.length, 1)
+    assert.equal(findings[0].type, 'label')
+    assert.match(findings[0].detail, /6-word button/)
+  })
+
+  test('button of five words or fewer is clean', () => {
+    const html = '<button data-option="a">Approve as written</button>'
+    assert.equal(readerChecks(html).filter((f) => f.type === 'label').length, 0)
+  })
+
+  test('a button without data-option is not checked', () => {
+    const html = '<button>Submit this very long label text here</button>'
+    assert.equal(readerChecks(html).filter((f) => f.type === 'label').length, 0)
+  })
+})
+
+describe('formatting', () => {
+  test('html tag printed as escaped text is flagged', () => {
+    const html = '<p>Use &lt;br to break lines.</p>'
+    const findings = readerChecks(html).filter((f) => f.type === 'formatting')
+    assert.equal(findings.length, 1)
+    assert.match(findings[0].detail, /html tag/)
+  })
+
+  test('unfilled placeholder is flagged', () => {
+    const html = '<p>PR {TICKET_ID} was merged.</p>'
+    const findings = readerChecks(html).filter((f) => f.type === 'formatting')
+    assert.equal(findings.length, 1)
+    assert.match(findings[0].detail, /placeholder/)
+  })
+
+  test('bare PR number with no link is flagged', () => {
+    const html = '<p>See #6485 for details.</p>'
+    const findings = readerChecks(html).filter((f) => f.type === 'formatting')
+    assert.equal(findings.length, 1)
+    assert.match(findings[0].detail, /PR number/)
+  })
+
+  test('linked PR number is not flagged', () => {
+    const html = '<p>See <a href="https://github.com/org/repo/pull/6485">#6485</a> for details.</p>'
+    assert.equal(readerChecks(html).filter((f) => f.type === 'formatting').length, 0)
+  })
+})
+
+describe('blockquote false positive fix', () => {
+  test('200-word paragraph inside a blockquote yields no wall finding', () => {
+    const html = `<blockquote>${wallP(200)}</blockquote>`
+    assert.equal(readerChecks(html).filter((f) => f.type === 'wall').length, 0)
+  })
+
+  test('escaped tags inside a blockquote yield no formatting finding', () => {
+    const html = '<blockquote><p>Example: &lt;br tags break lines.</p></blockquote>'
+    assert.equal(readerChecks(html).filter((f) => f.type === 'formatting').length, 0)
+  })
+
+  test('a wall paragraph outside a blockquote is still flagged', () => {
+    const html = `<blockquote>${wallP(200)}</blockquote>${wallP(112)}`
+    const walls = readerChecks(html).filter((f) => f.type === 'wall')
+    assert.equal(walls.length, 1)
+  })
+})
+
+describe('clean board', () => {
+  test('a well-formed board yields zero findings', () => {
+    const html = `
+      <table>
+        <tr><td>APR-01</td><td>approval queue card</td></tr>
+        <tr><td>SCR-01</td><td>screenshot service ticket</td></tr>
+      </table>
+      <p>APR-01 and SCR-01 are the two tickets in scope.</p>
+      <p>Each has a clear owner and a deadline.</p>
+      <button data-option="yes">Approve</button>
+      <button data-option="no">Defer</button>`
+    assert.equal(readerChecks(html).length, 0)
+  })
+})
+
+describe('formatFindings', () => {
+  test('returns empty string for zero findings', () => {
+    assert.equal(formatFindings([]), '')
+  })
+
+  test('includes reader checks header and bullet format', () => {
+    const findings = readerChecks(wallP(112))
+    const out = formatFindings(findings)
+    assert.match(out, /^reader checks:/)
+    assert.match(out, /• 112-word paragraph/)
+    assert.match(out, /rule:/)
+  })
+})


### PR DESCRIPTION
Every `easel publish` now prints what a cold reader would trip on, right under "published round N": wall paragraphs, long button labels, undefined internal names. Advisory only: nothing is refused, the exit code does not change, and there is no model call (the model reader pass is deferred; ledger row `easel-reader-pass`, 2026-09-25).

Two false positives from the audit board are fixed: every table cell now counts as a definition, not only the first column; and `<blockquote>` content is skipped, so a quoted specimen no longer reports as the author's own wall.

**Response shape:** the publish response gains `reader` (array of `{type, rule, detail, sample}`), separate from `audit`, which is the headless-render structural check. The unchanged-source path returns `reader: null`.

Sample output for a board with one 112-word paragraph and one 9-word button:

```
published round 2
reader checks:
• 112-word paragraph — "word word word word word word word word …"
    rule: Every paragraph takes the shape of what it is made of (authoring.md)
• 9-word button — "Approve as written with all specified conditions met …"
    rule: A decision carries the basis for answering it — the label is two or three words (authoring.md)
```

Files: `daemon/reader-checks.js` (fixes, header line, empty string when clean), `daemon/server.js` (runs the checks in `handlePublish`), `cli/easel.js` (prints them), `test/reader-checks.test.js` (21 tests: one fixture per finding type, both false-positive fixes, one rule-following board with zero findings).

Gate: `npm test` green, no regressions against the 707-test baseline on `main`.

Spec: board `http://127.0.0.1:4400/b/40dffc22`, section "PR C — Publish reads the board like a cold reader and tells the author". Independent of #21.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/The-Sentience-Company/codesmith/easel/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758787&installation_model_id=434752&pr_number=22&repository=The-Sentience-Company%2Feasel&return_to=https%3A%2F%2Fgithub.com%2FThe-Sentience-Company%2Feasel%2Fpull%2F22&signature=175d35ca685cf8010d7604ee5f5d2c713cde2734fd25afa762e29e96f57adf32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->