### PR TITLE
The queue is a thin list; the worker's own board orients you

### DIFF
--- a/docs/templates/queue.md
+++ b/docs/templates/queue.md
@@ -1,6 +1,8 @@
 # queue template
 
-One board per campaign: the single surface where decisions wait for the user. Open asks render first as cards with vote widgets, then a table of what the user has reviewed vs. what changed since, then the campaign's open PRs in merge order.
+One board per campaign: a thin list of the decisions waiting for the user, nothing else. A card is one question, the options with what each one causes, the recommended one marked, and a link to the board that orients the reader — written by the agent that did the work, not relayed by the one filing the card. Open asks render first, then a table of what the user has reviewed vs. what changed since, then the campaign's open PRs in merge order.
+
+**The card is not the place for the context.** When the ask comes from another agent, that agent publishes its own board (a `review` board with the design, the evidence, the diff) and the card carries it as `read_first`. A `context_link` to a ticket or a PR can ride along; it does not orient anyone. A card whose `body` runs past a few sentences is a relay that should have been a board.
 
 ```
 easel open --template queue --data queue-<campaign>.json --title "Decision queue — <campaign>"
@@ -17,11 +19,18 @@ The board is orchestrator-owned: one writer edits the data file and republishes;
     "id": "string",                  // required, unique among open entries — becomes the widget id
     "pane": "string",                // required — which agent pane asked
     "kind": "decision|review|merge", // required
-    "question": "string",            // required, plain English — the one-line ask
-    "title": "string",               // optional — short card title above the badges
-    "body": "string",                // optional, markdown — the brief behind the ask; collapses past ~400 chars
-    "options": ["string"],           // optional; default ["approve", "reject", "discuss"]
-    "context_link": "string",        // optional — board/PR/doc URL
+    "question": "string",            // required, plain English — the one-line ask; the sentence the reader answers
+    "title": "string",               // optional — short card title above the badges; not a second question
+    "read_first": {                  // optional — the board that orients the reader, by the agent that did the work
+      "url": "string", "title": "string", "by": "string"
+    },
+    "body": "string",                // optional, markdown — a few sentences at most; collapses past ~400 chars
+    "options": [                     // optional; default ["approve", "reject", "discuss"]
+      { "value": "string", "label": "string",   // label: two or three words, the words on the button
+        "basis": "string",                      // one line: what picking it causes
+        "recommended": true }                   // at most one
+    ],
+    "context_link": "string",        // optional — ticket/PR URL; rides beside read_first, never replaces it
     "filed_at": "ISO-8601 string",   // required
     "status": "open|answered"        // required
   }],
@@ -50,7 +59,8 @@ The board is orchestrator-owned: one writer edits the data file and republishes;
 ## Rendering rules
 
 - Open entries render before answered ones, each an accented card with a vote widget (`data-widget-id` = entry id). Answered entries render muted, badge only, no widget, inside a collapsed `sd-collapse` details block.
-- `title` renders as the card title; `body` renders as markdown under the question, folding into an `sd-collapse` when longer than ~400 characters so a long brief never buries the widget. Options with their consequences are one bullet per option (`authoring.md`'s paragraph rule), never `(1) … (2) …` inside one paragraph.
+- `read_first` renders as "Read first: <title> by <agent>" above the question. `title` renders as the card title; `body` renders as markdown under the question, folding into an `sd-collapse` when longer than ~400 characters.
+- Each option's `basis` renders as one bullet above the buttons, with the recommended one marked; the button shows only the `label`. **The consequence goes in `basis`, never in the label** — a label is also the value routed back to the pane, so a sentence-long label makes the recorded answer a paragraph. Options listed in the `question` or `body` as `(a) … (b) …` with the default approve/reject/discuss buttons underneath cannot be answered with a click; make them the options.
 - Each open entry carries `<time data-live-age datetime="...">` — the chrome recomputes "waiting 2h" from `filed_at` every 30s, so a long-open tab never shows a stale age.
 - A `review_stamps` row whose versions differ gets a warning badge; matching versions get "current".
 - Empty sections vanish; an empty `entries` list renders "Nothing waiting." — so a freshly seeded board (`{"campaign": "...", "entries": [], "review_stamps": [], "open_prs": []}`) publishes cleanly at wiring time.

--- a/templates/queue.js
+++ b/templates/queue.js
@@ -30,6 +30,12 @@ function validateEntry(e, i) {
   const filedMs = Date.parse(requireString(e.filed_at, `${path}.filed_at`))
   if (Number.isNaN(filedMs)) fail(`${path}.filed_at must be an ISO-8601 timestamp, got "${e.filed_at}"`)
   if (e.context_link !== undefined) requireString(e.context_link, `${path}.context_link`)
+  if (e.read_first !== undefined) {
+    requireObject(e.read_first, `${path}.read_first`)
+    requireString(e.read_first.url, `${path}.read_first.url`)
+    requireString(e.read_first.title, `${path}.read_first.title`)
+    if (e.read_first.by !== undefined) requireString(e.read_first.by, `${path}.read_first.by`)
+  }
   if (e.title !== undefined) requireString(e.title, `${path}.title`)
   if (e.body !== undefined) requireString(e.body, `${path}.body`)
   if (status === 'open' && kind !== 'merge' && !e.body && !e.context_link) {
@@ -61,6 +67,12 @@ function entryBody(body) {
   return `<details class="sd-collapse"><summary>the brief</summary><div class="sd-collapse-body">${markdown(body)}</div></details>`
 }
 
+// The orientation is a board by the agent that did the work; the card links
+// it instead of carrying a relay of it.
+function readFirst(r) {
+  return `<p class="sd-read-first">Read first: <a href="${attr(r.url)}">${esc(r.title)}</a>${r.by ? `<span class="sd-muted"> by ${esc(r.by)}</span>` : ''}</p>`
+}
+
 function entryCard(e, i, uniqueId) {
   const open = e.status === 'open'
   const meta = [
@@ -73,6 +85,7 @@ function entryCard(e, i, uniqueId) {
     `<div class="sd-card${open ? ' sd-accent' : ''}">`,
     e.title ? `<div class="sd-card-title">${esc(e.title)}</div>` : '',
     `<div class="sd-row sd-badge-row">${meta}</div>`,
+    e.read_first ? readFirst(e.read_first) : '',
     open ? `<p><strong>${esc(e.question)}</strong></p>` : `<p class="sd-muted">${esc(e.question)}</p>`,
     entryBody(e.body),
     open

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -1043,6 +1043,74 @@ describe('queue', () => {
     assert.match(section, /<a href="http:\/\/127\.0\.0\.1:4400\/b\/deadbeef">design coverage<\/a>/)
     assert.match(section, /phase plan with per-PR coverage/)
   })
+
+  test('read_first validation errors name the full field path', async () => {
+    const data = await base()
+    data.entries[0].read_first = { url: '', title: 'Design board', by: 'agent-a' }
+    assert.throws(() => queue.render(data), (err) => {
+      assert.ok(err instanceof TemplateError)
+      assert.match(err.message, /entries\[0\]\.read_first\.url/)
+      return true
+    })
+    data.entries[0].read_first = { url: 'http://localhost/b/abc', title: '' }
+    assert.throws(() => queue.render(data), (err) => {
+      assert.match(err.message, /entries\[0\]\.read_first\.title/)
+      return true
+    })
+    data.entries[0].read_first = { url: 'http://localhost/b/abc', title: 'Board', by: 42 }
+    assert.throws(() => queue.render(data), (err) => {
+      assert.match(err.message, /entries\[0\]\.read_first\.by/)
+      return true
+    })
+  })
+
+  test('read_first renders above the question, with and without by', async () => {
+    const data = await base()
+    data.entries[0].read_first = { url: 'http://localhost/b/xyz', title: 'Design notes', by: 'agent-a' }
+    const htmlWith = queue.render(data)
+    const cardWith = htmlWith.slice(htmlWith.indexOf('design-note-extraction-table') - 500, htmlWith.indexOf('design-note-extraction-table') + 3000)
+    assert.match(cardWith, /class="sd-read-first"/)
+    assert.match(cardWith, /<a href="http:\/\/localhost\/b\/xyz">Design notes<\/a>/)
+    assert.match(cardWith, /by agent-a/)
+    const readFirstPos = cardWith.indexOf('sd-read-first')
+    const questionPos = cardWith.indexOf('<strong>')
+    assert.ok(readFirstPos < questionPos, 'read_first must appear before the question')
+
+    data.entries[0].read_first = { url: 'http://localhost/b/xyz', title: 'Design notes' }
+    const htmlWithout = queue.render(data)
+    assert.match(htmlWithout, /class="sd-read-first"/)
+    assert.doesNotMatch(htmlWithout.slice(htmlWithout.indexOf('sd-read-first'), htmlWithout.indexOf('sd-read-first') + 200), /by /)
+  })
+
+  test('string options still produce the approve/reject/discuss default when omitted', async () => {
+    const data = await base()
+    delete data.entries[0].options
+    const html = queue.render(data)
+    for (const opt of ['approve', 'reject', 'discuss']) {
+      assert.ok(html.includes(`data-option="${opt}"`), `default option ${opt} missing`)
+    }
+    data.entries[1].options = ['yes', 'no']
+    const html2 = queue.render(data)
+    assert.ok(html2.includes('data-option="yes"'))
+    assert.ok(html2.includes('data-option="no"'))
+  })
+
+  test('option objects with basis and recommended render the basis list above the buttons', async () => {
+    const data = await base()
+    data.entries[0].options = [
+      { value: 'approve', label: 'Approve', basis: 'Ships the design as-is.', recommended: true },
+      { value: 'reject', label: 'Reject', basis: 'Blocks the PR until revised.' },
+    ]
+    const html = queue.render(data)
+    const card = html.slice(html.indexOf('design-note-extraction-table') - 500, html.indexOf('design-note-extraction-table') + 3000)
+    assert.match(card, /class="sd-widget-basis"/)
+    assert.match(card, /Ships the design as-is\./)
+    assert.match(card, /Blocks the PR until revised\./)
+    assert.match(card, /class="sd-widget-pick">recommended</)
+    const basisPos = card.indexOf('sd-widget-basis')
+    const buttonsPos = card.indexOf('sd-widget-options')
+    assert.ok(basisPos < buttonsPos, 'basis list must appear above the buttons')
+  })
 })
 
 describe('replay', () => {


### PR DESCRIPTION
A queue card can now carry `read_first: {url, title, by}`, rendered as "Read first: <title> by <agent>" above the question. The card links the agent's board instead of relaying its contents — the coordinator writes entries this way from now on, guided by the updated doc. Options are the PR B objects with `basis` and `recommended`, so the consequence lives above the buttons, not in the label.

Stacked on #21.

**Files changed**
- `templates/queue.js` — `read_first` validation and rendering (+13 lines from prototype)
- `docs/templates/queue.md` — new opening paragraph, schema block updated to show `read_first` and object options, rendering rules rewritten
- `test/templates.test.js` — 4 new tests: path-named validation errors, renders above question with/without `by`, string options default unchanged, object options render basis list above buttons

**Test gate:** 714 pass, 0 fail (baseline main 707, PR B 710; +4 new tests)

**Spec:** http://127.0.0.1:4400/b/40dffc22 (PR A section)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/The-Sentience-Company/codesmith/easel/pr/23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758817&installation_model_id=434752&pr_number=23&repository=The-Sentience-Company%2Feasel&return_to=https%3A%2F%2Fgithub.com%2FThe-Sentience-Company%2Feasel%2Fpull%2F23&signature=5e53018fabf6cf15723dbb39b757e4d768d32747d742bfb9fcd119f3a034e44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->