### PR TITLE
The rules arrive when they apply

### DIFF
--- a/cli/easel.js
+++ b/cli/easel.js
@@ -6,9 +6,44 @@ import { parseArgs } from 'node:util'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { formatFindings } from '../daemon/reader-checks.js'
 
 const BASE = process.env.EASEL_URL || 'http://127.0.0.1:4400'
+
+const TEMPLATE_RULES = {
+  queue:
+    'a queue card is: one question on one line · options as buttons, each with a one-line basis, one recommended\n' +
+    '· read_first = the board by the agent that did the work · a body of a few sentences · no card id or callsign without a gloss',
+  review:
+    'a review decision is: a question with options as buttons, each with a one-line basis, one recommended\n' +
+    '· evidence goes in the detail field above the options, not on the button · no term without a gloss',
+  compare:
+    'a compare verdict is: pick the winning arm, or tie, or all-bad · the comparison sits above the verdict, not a pointer elsewhere\n' +
+    '· no arm name or case id without a gloss at first use',
+  eval:
+    'a dossier verdict is: pass or needs-work after the notes · a blind compare pick: the better candidate, unlabeled\n' +
+    '· a matrix best: strongest answer per row; overall verdict per case · no dataset or model id without a gloss',
+  gallery:
+    'a gallery vote is: pick the candidate that ships, or none of these · the image is the argument, not a description of it\n' +
+    '· pin width to the size the design actually ships at · no variant name without a label',
+  replay:
+    'a replay verdict is: pick which arm held up on this exchange, or tie, or all-bad\n' +
+    '· the user message and each arm\'s reply are above the verdict · no arm name without a gloss at first use',
+  rulings:
+    'a ruling is: a label and rationale, then a vote widget — accept or override\n' +
+    '· skim sections (options: []) have no buttons · no label without a plain-language meaning in the teach block',
+  // page has no decision UI — no rule block
+}
+
+function hasDecisions(content) {
+  if (content.includes('What I need from you') || content.includes('Recommendation:')) return true
+  const lines = content.split('\n')
+  for (let i = 0; i + 1 < lines.length; i++) {
+    if (/^#{1,6}\s/.test(lines[i]) && lines[i + 1].trimEnd().endsWith('?')) return true
+  }
+  return false
+}
 
 const USAGE = `usage:
   easel open <file.html|file.md> [--title T] [--json]
@@ -113,6 +148,17 @@ const commands = {
     }
     const data = await call('POST', '/api/open', body)
     output(data, values.json, (d) => `${d.created ? 'opened' : 'already open'}: ${d.url}`)
+    if (!values.json) {
+      if (values.template && TEMPLATE_RULES[values.template]) {
+        console.log(TEMPLATE_RULES[values.template])
+      } else if (!values.template && body.file?.endsWith('.md')) {
+        try {
+          if (hasDecisions(readFileSync(body.file, 'utf8'))) {
+            console.log('this file has decisions in it — the review template gives them buttons; `easel open --template review` with the questions as decisions')
+          }
+        } catch {}
+      }
+    }
   },
 
   async publish() {
@@ -182,6 +228,7 @@ const commands = {
       backoff = 1000
       if (data.timedOut) continue // window expired — re-attach with the same cursor
       output(data, values.json)
+      if (!values.json) console.log('answer each item on the board, at its anchor, in the next round')
       // Both are normal lifecycle events, not failures — exit 0.
       if (data.superseded) console.error('superseded by a newer await from this agent')
       if (data.dropped) console.error('dropped by a publish from this agent — relaunch after the round')

--- a/skills/easel/SKILL.md
+++ b/skills/easel/SKILL.md
@@ -20,6 +20,17 @@ After publishing, the chat message is the link, one line on what changed, and wh
 
 **A subagent has the Artifact tool and does not have this skill.** When you delegate work that ends in something the user reviews, say in the prompt that the deliverable is an easel board and hand over the key — otherwise it publishes an Artifact the user cannot annotate.
 
+## Six things every board carries
+
+The reader stops and spends a comment when one of these is missing — `references/authoring.md` has the why and the rest.
+
+1. **A term table** before the first section when the board leans on three or more internal names (card ids, callsigns, names this session coined); every other internal name glossed in the sentence that first uses it.
+2. **One bullet per option, the pick marked**, above the buttons; the button is two or three words.
+3. **Restate, never point**: whatever the reader acts on is on this round, not "see round 9" or a path.
+4. **The artifact, not a description of it**: the diff, the payload, the rendered option, the image.
+5. **Every paragraph takes the shape of what it is made of**: options, terms, labeled facts and steps are lists or tables, never one paragraph.
+6. **The first line states the ask**: how many decisions, the first one by name, what blocks.
+
 ## Publish
 
 ```
@@ -54,21 +65,12 @@ A ```` ```chart ```` fence renders a small themed bar/hbar/line chart at publish
 
 **Publish reads the REGISTERED path, nothing else.** The source path is fixed at `easel open`; `easel status <key>` shows it. Before every publish, write your new content to THAT path — writing any other file makes `publish` silently re-ship the stale registered file as a new round. This shipped two stale rounds once.
 
-## Listen — always `easel await`, never hand-rolled waiters
+## Listen
 
 ```
 easel await <key> [--agent ID] [--ack N]
 ```
-
-Blocks until real feedback, cancel, or board end — it re-attaches across long-poll timeouts and daemon restarts, so run it once and stop polling (`--timeout-s` sizes one poll window, never the overall wait). Annotations, widget clicks, and chat ride the same stream; answer chat with `easel reply <key> "msg" --agent ID`.
-
-- **Background it as a harness-tracked command** (`run_in_background: true`) — its exit wakes you to read the batch. A shell `&`/`nohup` launch exits into a file no one reads.
-- **Relaunch once after each publish** — publishing with your own agent ID drops your parked listener (`dropped: true`, exit 0, expected).
-- **A killed listener is a non-event**: relaunch the identical bare await in one call and say nothing — the cursor is server-side, nothing was lost. If it's killed instantly twice running, or for why this is safe: `references/listening.md`.
-- **Ack what you've handled**: relaunch with `--ack <upto>` from the batch you just applied, or the backlog re-delivers and you answer the same annotations twice.
-- **`--agent` IDs are workspace-scoped and durable** — worktree basename + callsign (`my-project-a3:a3`); a bare callsign collides with other workspaces. A NEW ID replays the board's whole history. A handoff that names live boards must name the agent ID they were listened on.
-- **Refer to feedback by chip ID (A1, A2 …), never internal item ids** — the chips are what the user sees. Derivation, and placing feedback via anchor `context`: `references/listening.md`.
-- **An answer given in prose is still an answer.** When the reader states a decision plainly — in board chat, in an annotation, or in the session itself — record it and act on it. Never hold a decision open waiting for the matching widget click, and never re-ask what they already answered; the widget is one way to answer, not the only one.
+Background it (`run_in_background: true`); relaunch once after each publish; ack with `--ack <upto>` what you've handled. Answer chat with `easel reply <key> "msg" --agent ID`. Full mechanics, chip IDs, and failure modes: `references/listening.md`.
 
 ## Iterate
 
@@ -76,7 +78,7 @@ Applying 3+ annotations: one script that makes every edit, each replacement asse
 
 **The `--note` is one line, ~200 characters hard cap** — it renders on a single line in the round picker and anything longer is truncated. At the limit: `round 4: your three widget answers are recorded as decisions taken (history merge yes, backend-first rollout, account-linking as a hard billing gate). Dropped the post-deletion payment-traceability requirement`. Detail belongs on the board, not in the note.
 
-**Earlier rounds are never buried.** The chrome has a round picker (r1/r2 pills, Q/W); an agent reads one with `GET /api/b/<key>/state?round=N`. Point at the round ("the map is r5"), never republish old content to resurface it. For a clean visual round with no diff markers: `easel end <key>` and re-open from the same data file.
+**Earlier rounds are never buried.** The chrome has a round picker (r1/r2 pills, Q/W); an agent reads one with `GET /api/b/<key>/state?round=N`. Anything the current round *uses* from an earlier one — a ruling, a number, a decision — is restated on the current round where it is used (`references/authoring.md`, "Restate, never point"); the round link accompanies the restatement. Pointing alone ("the map is r5") is for content the reader is not being asked to act on. For a clean visual round with no diff markers: `easel end <key>` and re-open from the same data file.
 
 ## Cleanup
 

--- a/skills/easel/references/authoring.md
+++ b/skills/easel/references/authoring.md
@@ -15,7 +15,7 @@ A round that asks about an option and does not render that option burns the roun
 
 ## Gloss every internal name, the first time it appears
 
-Table, column, service, job, model id, flag, code path, acronym, campaign shorthand — and the board's own numbering. The gloss is the words themselves, not a link out, in the sentence that first uses the name; when the board leans on three or more such names, gloss them in a term | meaning table before the first section. This is the single most common reason a reader stops to ask a question instead of answering the one you asked.
+Table, column, service, job, model id, flag, code path, acronym, campaign shorthand — and the board's own numbering. An internal name is any name that did not exist before this project, or that this session coined: a card id, a pane callsign, a label like "Fix 4(a)" or "arm B", a phrase from a design note. The test is not whether *you* know it; it is whether the reader could have met it anywhere but here. The gloss is the words themselves, not a link out, in the sentence that first uses the name; when the board leans on three or more such names, gloss them in a term | meaning table before the first section. This is the single most common reason a reader stops to ask a question instead of answering the one you asked.
 
 ## Restate, never point
 

--- a/skills/easel/references/listening.md
+++ b/skills/easel/references/listening.md
@@ -1,6 +1,18 @@
-# Listening — failure modes and feedback mechanics
+# Listening — `easel await` mechanics and failure modes
 
-The SKILL.md rules are the behavior; this file is the why and the edge cases. Read it when a listener misbehaves or when placing/attributing feedback needs more than the batch JSON gives you.
+```
+easel await <key> [--agent ID] [--ack N]
+```
+
+Blocks until real feedback, cancel, or board end — it re-attaches across long-poll timeouts and daemon restarts, so run it once and stop polling (`--timeout-s` sizes one poll window, never the overall wait). Annotations, widget clicks, and chat ride the same stream; answer chat with `easel reply <key> "msg" --agent ID`.
+
+- **Background it as a harness-tracked command** (`run_in_background: true`) — its exit wakes you to read the batch. A shell `&`/`nohup` launch exits into a file no one reads.
+- **Relaunch once after each publish** — publishing with your own agent ID drops your parked listener (`dropped: true`, exit 0, expected).
+- **A killed listener is a non-event**: relaunch the identical bare await in one call and say nothing — the cursor is server-side, nothing was lost. If it's killed instantly twice running, see "Fallback when relaunches die instantly" below.
+- **Ack what you've handled**: relaunch with `--ack <upto>` from the batch you just applied, or the backlog re-delivers and you answer the same annotations twice.
+- **`--agent` IDs are workspace-scoped and durable** — worktree basename + callsign (`my-project-a3:a3`); a bare callsign collides with other workspaces. A NEW ID replays the board's whole history. A handoff that names live boards must name the agent ID they were listened on.
+- **Refer to feedback by chip ID (A1, A2 …), never internal item ids** — the chips are what the user sees. Derivation: "Chip IDs" below.
+- **An answer given in prose is still an answer.** When the reader states a decision plainly — in board chat, in an annotation, or in the session itself — record it and act on it. Never hold a decision open waiting for the matching widget click, and never re-ask what they already answered; the widget is one way to answer, not the only one.
 
 ## Why a killed listener costs nothing
 

--- a/test/cli-prints.test.js
+++ b/test/cli-prints.test.js
@@ -1,0 +1,193 @@
+/* CLI print behavior: template rule blocks, markdown nudge, await trailer. */
+
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFile, spawn } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { startDaemon, waitHealthy, makeApi, portFor } from './harness.js'
+
+const pExecFile = promisify(execFile)
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const PORT = portFor(import.meta.url)
+const BASE = `http://127.0.0.1:${PORT}`
+const DATA_DIR = mkdtempSync(join(tmpdir(), 'sf-cli-prints-'))
+
+let daemon
+const api = makeApi(BASE)
+
+function cli(...args) {
+  return pExecFile('node', [join(ROOT, 'cli', 'easel.js'), ...args], {
+    env: { ...process.env, EASEL_URL: BASE },
+  })
+}
+
+before(async () => {
+  daemon = startDaemon(PORT, DATA_DIR)
+  await waitHealthy(BASE)
+})
+
+after(() => daemon?.kill())
+
+// --- template rule blocks ---
+
+test('open --template queue prints the spec rule block after the URL', async () => {
+  const dataFile = join(DATA_DIR, 'queue.json')
+  writeFileSync(dataFile, JSON.stringify({
+    campaign: 'test',
+    entries: [],
+    review_stamps: [],
+    open_prs: [],
+  }))
+  const { stdout } = await cli('open', '--template', 'queue', '--data', dataFile, '--title', 'Test queue')
+  const lines = stdout.trim().split('\n')
+  assert.ok(lines.length >= 2, 'should have URL line plus rule block')
+  const ruleText = lines.slice(1).join('\n')
+  assert.ok(
+    ruleText.includes('a queue card is:'),
+    `rule block should start with "a queue card is:", got: ${ruleText}`,
+  )
+  assert.ok(ruleText.includes('one question on one line'), 'rule mentions one question on one line')
+  assert.ok(ruleText.includes('one-line basis, one recommended'), 'rule mentions basis and recommended')
+  assert.ok(ruleText.includes('no card id or callsign without a gloss'), 'rule mentions gloss requirement')
+})
+
+test('open --template queue rule block matches spec text exactly', async () => {
+  const dataFile = join(DATA_DIR, 'queue2.json')
+  writeFileSync(dataFile, JSON.stringify({ campaign: 'x', entries: [], review_stamps: [], open_prs: [] }))
+  const { stdout } = await cli('open', '--template', 'queue', '--data', dataFile, '--title', 'Q2')
+  const lines = stdout.trim().split('\n')
+  const ruleBlock = lines.slice(1).join('\n')
+  const expected =
+    'a queue card is: one question on one line · options as buttons, each with a one-line basis, one recommended\n' +
+    '· read_first = the board by the agent that did the work · a body of a few sentences · no card id or callsign without a gloss'
+  assert.equal(ruleBlock, expected)
+})
+
+test('open --template page prints no rule block (no structured decision UI)', async () => {
+  const dataFile = join(DATA_DIR, 'page.json')
+  writeFileSync(dataFile, JSON.stringify({ title: 'Page', html: '<p>hello</p>' }))
+  const { stdout } = await cli('open', '--template', 'page', '--data', dataFile, '--title', 'Page')
+  const lines = stdout.trim().split('\n')
+  assert.equal(lines.length, 1, `page template should print only the URL line, got: ${stdout}`)
+})
+
+test('open --template review prints a rule block', async () => {
+  const dataFile = join(DATA_DIR, 'review.json')
+  writeFileSync(dataFile, JSON.stringify({
+    title: 'Test',
+    sections: [{ heading: 'S', body: 'body' }],
+  }))
+  const { stdout } = await cli('open', '--template', 'review', '--data', dataFile, '--title', 'Review')
+  const lines = stdout.trim().split('\n')
+  assert.ok(lines.length >= 2, 'review should have a rule block')
+  assert.ok(stdout.includes('a review decision is:'), 'review rule block present')
+})
+
+// --- markdown nudge ---
+
+test('open plain .md with "What I need from you" prints nudge', async () => {
+  const mdFile = join(DATA_DIR, 'decisions1.md')
+  writeFileSync(mdFile, '# Plan\n\nWhat I need from you: approve or reject.\n')
+  const { stdout } = await cli('open', mdFile, '--title', 'decisions1')
+  assert.ok(
+    stdout.includes('this file has decisions in it'),
+    `nudge should appear, got: ${stdout}`,
+  )
+})
+
+test('open plain .md with "Recommendation:" prints nudge', async () => {
+  const mdFile = join(DATA_DIR, 'decisions2.md')
+  writeFileSync(mdFile, '# Proposal\n\nRecommendation: go with option A.\n')
+  const { stdout } = await cli('open', mdFile, '--title', 'decisions2')
+  assert.ok(stdout.includes('this file has decisions in it'), `nudge should appear, got: ${stdout}`)
+})
+
+test('open plain .md with question mark directly under heading prints nudge', async () => {
+  const mdFile = join(DATA_DIR, 'decisions3.md')
+  writeFileSync(mdFile, '# Section\nShould we do this?\n\nMore text.\n')
+  const { stdout } = await cli('open', mdFile, '--title', 'decisions3')
+  assert.ok(stdout.includes('this file has decisions in it'), `nudge should appear, got: ${stdout}`)
+})
+
+test('open plain .md with no decision markers prints no nudge', async () => {
+  const mdFile = join(DATA_DIR, 'plain.md')
+  writeFileSync(mdFile, '# Section\n\nJust a paragraph with no decisions.\n')
+  const { stdout } = await cli('open', mdFile, '--title', 'plain')
+  assert.ok(!stdout.includes('this file has decisions in it'), `nudge should NOT appear, got: ${stdout}`)
+})
+
+test('open .md nudge is suppressed with --json', async () => {
+  const mdFile = join(DATA_DIR, 'decisions-json.md')
+  writeFileSync(mdFile, '# Plan\n\nWhat I need from you: approve.\n')
+  const { stdout } = await cli('open', '--json', mdFile)
+  assert.ok(!stdout.includes('this file has decisions in it'), `nudge should be absent in json mode, got: ${stdout}`)
+  // should be valid JSON
+  assert.doesNotThrow(() => JSON.parse(stdout))
+})
+
+// --- await trailer ---
+
+test('easel await batch output ends with the trailer line', async () => {
+  // Open a board and post a chat message so await gets real feedback
+  const pageFile = join(DATA_DIR, 'await-trailer.html')
+  writeFileSync(pageFile, '<h1>Trailer</h1><p>text</p>')
+  const { data: openData } = await api('POST', '/api/open', { file: pageFile, title: 'await-trailer' })
+  const key = openData.key
+  const { data: state } = await api('GET', `/api/b/${key}/state?round=1`)
+  const sid = state.currentRound.html.match(/data-sid="([^"]+)"/)[1]
+
+  const agentId = 'cli-prints-test:t1'
+  // Start the await before feedback arrives
+  const child = spawn('node', [join(ROOT, 'cli', 'easel.js'), 'await', key, '--agent', agentId], {
+    env: { ...process.env, EASEL_URL: BASE },
+  })
+  let stdout = ''
+  child.stdout.on('data', (d) => (stdout += d))
+
+  // Give it a moment to attach, then post feedback
+  await new Promise((r) => setTimeout(r, 300))
+  await api('POST', `/api/b/${key}/feedback`, {
+    clientId: 'test-client', round: 1, anchor: { sid }, comment: 'looks good',
+  })
+  await api('POST', `/api/b/${key}/send`, { clientId: 'test-client' })
+
+  await new Promise((resolve) => child.on('exit', resolve))
+  assert.ok(
+    stdout.includes('answer each item on the board, at its anchor, in the next round'),
+    `trailer line should appear in stdout, got: ${stdout}`,
+  )
+})
+
+test('easel await --json batch output does NOT include trailer line', async () => {
+  const pageFile = join(DATA_DIR, 'await-trailer-json.html')
+  writeFileSync(pageFile, '<h1>Trailer JSON</h1><p>content</p>')
+  const { data: openData } = await api('POST', '/api/open', { file: pageFile, title: 'await-trailer-json' })
+  const key = openData.key
+  const { data: state } = await api('GET', `/api/b/${key}/state?round=1`)
+  const sid = state.currentRound.html.match(/data-sid="([^"]+)"/)[1]
+
+  const agentId = 'cli-prints-test:t2'
+  const child = spawn('node', [join(ROOT, 'cli', 'easel.js'), 'await', key, '--agent', agentId, '--json'], {
+    env: { ...process.env, EASEL_URL: BASE },
+  })
+  let stdout = ''
+  child.stdout.on('data', (d) => (stdout += d))
+
+  await new Promise((r) => setTimeout(r, 300))
+  await api('POST', `/api/b/${key}/feedback`, {
+    clientId: 'test-client-j', round: 1, anchor: { sid }, comment: 'ok',
+  })
+  await api('POST', `/api/b/${key}/send`, { clientId: 'test-client-j' })
+
+  await new Promise((resolve) => child.on('exit', resolve))
+  assert.ok(
+    !stdout.includes('answer each item on the board'),
+    `trailer should be absent in json mode, got: ${stdout}`,
+  )
+  // stdout should be valid JSON
+  assert.doesNotThrow(() => JSON.parse(stdout.trim()))
+})


### PR DESCRIPTION
The listener mechanics move out of SKILL.md into `references/listening.md` (the file already existed as the "why"; it now holds the complete how-to plus the edge cases). The three CLI prints land: `easel open --template <t>` prints a one-to-two-line rule block right after the URL, `easel open <file.md>` prints a nudge when the file has decision markers, and `easel await` ends every batch with "answer each item on the board, at its anchor, in the next round".

Stacked on #21.

## Files

- `skills/easel/SKILL.md` — Listen section collapsed to 3 lines + pointer; six-rules block and restate-never-point already on branch
- `skills/easel/references/listening.md` — full mechanics merged in; intro updated
- `skills/easel/references/authoring.md` — internal-name definition already on branch
- `cli/easel.js` — `TEMPLATE_RULES` map, `hasDecisions()`, open prints, await trailer
- `test/cli-prints.test.js` — 11 new tests

## Test gate

721 pass, 0 fail (was 710 on pr-b-buttons baseline before my tests).

## Captured CLI output

```
$ easel open --template queue --data q.json --title "Decision queue — x"
opened: http://127.0.0.1:14451/b/68c52aad
a queue card is: one question on one line · options as buttons, each with a one-line basis, one recommended
· read_first = the board by the agent that did the work · a body of a few sentences · no card id or callsign without a gloss

$ easel open design-note.md --title "design-note"
opened: http://127.0.0.1:14451/b/6ff61366
this file has decisions in it — the review template gives them buttons; `easel open --template review` with the questions as decisions

$ easel await <key> --agent pr-d-test:a1
{"items":[{"id":1,"round":1,"kind":"annotation","anchor":{"sid":"..."},"comment":"looks good"}],"upto":1}
answer each item on the board, at its anchor, in the next round
```

Spec: http://127.0.0.1:4400/b/40dffc22 PR D section

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/The-Sentience-Company/codesmith/easel/pr/24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791759559&installation_model_id=434752&pr_number=24&repository=The-Sentience-Company%2Feasel&return_to=https%3A%2F%2Fgithub.com%2FThe-Sentience-Company%2Feasel%2Fpull%2F24&signature=20cfcc977b6024538af9e7c6151f837e97f09d868c45b254c6e65b81e99ca248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->