### PR TITLE
Run the reader checks on round 1 too, where open publishes it

### DIFF
--- a/cli/easel.js
+++ b/cli/easel.js
@@ -158,6 +158,7 @@ const commands = {
           }
         } catch {}
       }
+      if (data.reader?.length) console.log(formatFindings(data.reader))
     }
   },
 

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -777,7 +777,7 @@ async function handleOpen(req, res) {
   store.addRound(key, 1, sidHtml, null, null, audit, rendered.diagrams, islands)
   store.setAudit(key, audit)
   watchBoard(board)
-  json(res, 200, { key, url: `http://127.0.0.1:${PORT}/b/${key}`, created: true })
+  json(res, 200, { key, url: `http://127.0.0.1:${PORT}/b/${key}`, created: true, reader: readerChecks(sidHtml) })
 }
 
 async function handlePublish(req, res, match) {

--- a/test/reader-open.e2e.test.js
+++ b/test/reader-open.e2e.test.js
@@ -1,0 +1,38 @@
+/* Round 1 comes from open, not publish; the author must see the reader checks there too. */
+
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { startDaemon, waitHealthy, makeApi, portFor } from './harness.js'
+
+const PORT = portFor(import.meta.url)
+const BASE = `http://127.0.0.1:${PORT}`
+const DIR = mkdtempSync(join(tmpdir(), 'sf-reader-open-'))
+const api = makeApi(BASE)
+let daemon
+
+const source = (name, body) => {
+  const path = join(DIR, `${name}.json`)
+  writeFileSync(path, JSON.stringify(body))
+  return path
+}
+
+before(async () => {
+  daemon = startDaemon(PORT, DIR)
+  await waitHealthy(BASE)
+})
+after(() => daemon?.kill())
+
+test('open returns the reader checks for round 1', async () => {
+  const wall = `<p>${'the server keeps one cursor per agent and the retry path reuses it '.repeat(20)}</p>`
+  const { data } = await api('POST', '/api/open', { template: 'page', data: source('wall', { title: 'w', html: wall }) })
+  assert.ok(Array.isArray(data.reader), 'reader is an array on a created board')
+  assert.ok(data.reader.some((f) => f.type === 'wall'), `expected a wall finding, got ${JSON.stringify(data.reader)}`)
+})
+
+test('a board that follows the rules opens with no findings', async () => {
+  const { data } = await api('POST', '/api/open', { template: 'page', data: source('clean', { title: 'c', html: '<p>one short line.</p>' }) })
+  assert.deepEqual(data.reader, [])
+})


### PR DESCRIPTION
Round 1 of every board comes from `easel open`, not `easel publish`, so after #22 the author saw the reader checks only from round 2 on. The open path now runs the same checks and returns them as `reader`; the CLI prints them after the URL line and the template rule block.

Verified against the live daemon: a queue board opened with a 150-word body now prints the wall finding at open time, where before it printed nothing until the next publish.

Test: `test/reader-open.e2e.test.js` (a wall paragraph yields a finding on open; a clean board yields an empty array).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/The-Sentience-Company/codesmith/easel/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791769079&installation_model_id=434752&pr_number=25&repository=The-Sentience-Company%2Feasel&return_to=https%3A%2F%2Fgithub.com%2FThe-Sentience-Company%2Feasel%2Fpull%2F25&signature=f7debf573f28a14f976d0e7ecd658478e529c75538da46b78af7d14e1bed2a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->