### PR TITLE
Skip baked diagrams and style blocks in the reader checks

### DIFF
--- a/daemon/reader-checks.js
+++ b/daemon/reader-checks.js
@@ -14,7 +14,8 @@ const RULES = {
 }
 
 export function readerChecks(html) {
-  html = html.replace(/<blockquote[\s\S]*?<\/blockquote>/gi, ' ')
+  // Quoted specimens are not the author's prose; baked diagrams and styles are not prose at all.
+  html = html.replace(/<(blockquote|svg|style)\b[\s\S]*?<\/\1>/gi, ' ')
   const findings = []
   const add = (type, detail, sample) => findings.push({ type, rule: RULES[type], detail, sample })
 

--- a/test/reader-checks.test.js
+++ b/test/reader-checks.test.js
@@ -129,6 +129,16 @@ describe('blockquote false positive fix', () => {
     const walls = readerChecks(html).filter((f) => f.type === 'wall')
     assert.equal(walls.length, 1)
   })
+
+  test('hex colours inside a baked diagram or a style block are not bare PR numbers', () => {
+    const html = '<svg><g style="fill:#333;stroke:#000"><text>node</text></g></svg><style>.x{color:#a5d8ff}</style><p>one short line.</p>'
+    assert.equal(readerChecks(html).filter((f) => f.type === 'formatting').length, 0)
+  })
+
+  test('a bare PR number in prose is still flagged', () => {
+    const html = '<svg><g style="fill:#333"></g></svg><p>merged as #4123 this morning.</p>'
+    assert.equal(readerChecks(html).filter((f) => f.type === 'formatting').length, 1)
+  })
 })
 
 describe('clean board', () => {


### PR DESCRIPTION
The "PR number with no link" check read hex colours out of baked mermaid SVGs and style blocks as bare PR numbers, so any board with a diagram reported "13 PR numbers with no link — #333 #000". Rendered diagrams and styles are now stripped before any scan, alongside blockquotes.

Seen on the first board published after #25. Two tests: hex colours in an svg or style block yield no finding; a real bare number in prose still does.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/The-Sentience-Company/codesmith/easel/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791769599&installation_model_id=434752&pr_number=26&repository=The-Sentience-Company%2Feasel&return_to=https%3A%2F%2Fgithub.com%2FThe-Sentience-Company%2Feasel%2Fpull%2F26&signature=e1af027beaacd9b548cf1a925099e508946b96de60f1f0d6ab9cceeeb14e1ebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->